### PR TITLE
docs: refresh stale markdown content

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ andy-acp/
 ## Building and Testing
 
 ### Prerequisites
-- .NET 9.0 SDK or later
+- .NET 8.0 SDK or later
 
 ### Build
 ```bash

--- a/docs/ZED_INTEGRATION_TESTING.md
+++ b/docs/ZED_INTEGRATION_TESTING.md
@@ -5,7 +5,7 @@ This document provides a comprehensive guide for testing the Andy ACP implementa
 ## Prerequisites
 
 1. **Zed Editor** installed (download from [zed.dev](https://zed.dev/))
-2. **.NET 9.0 SDK** or later
+2. **.NET 8.0 SDK** or later
 3. **andy-acp repository** cloned and built
 
 ## Setup


### PR DESCRIPTION
## Summary

Markdown sweep targeting fact-level staleness. Out of scope: license headers, prose/style, section reorganization, generated docs.

- `README.md` and `docs/ZED_INTEGRATION_TESTING.md`: both listed `.NET 9.0 SDK` as a prerequisite, but every csproj in this repo (`Andy.Acp.Core`, `Andy.Acp.Server`, `SimpleEchoAgent`, `Andy.Acp.Examples`, `Andy.Acp.Tests`) targets `net8.0`. Even the SimpleEchoAgent README and the README's own Zed-config snippet point at `bin/Release/net8.0/`. Updated to `.NET 8.0 SDK`.

The rest of the corpus (ACP_IMPLEMENTATION_PLAN, TOOLS_COMPARISON, examples READMEs) cross-checked against the actual classes (IAgentProvider, IResponseStreamer, AcpServer) — no other stale items found.

## Test plan

- [ ] CI passes (build runs on net8.0)
- [ ] `grep TargetFramework src/**/*.csproj examples/**/*.csproj tests/**/*.csproj` shows net8.0 everywhere