### PR TITLE
fix: harden JSON-RPC, stdio framing, and runtime lifecycle (#15, #18, #19, #20)

### DIFF
--- a/src/Andy.Acp.Core/JsonRpc/JsonRpcHandler.cs
+++ b/src/Andy.Acp.Core/JsonRpc/JsonRpcHandler.cs
@@ -100,11 +100,11 @@ namespace Andy.Acp.Core.JsonRpc
 
                 if (!request.IsNotification)
                 {
+                    // Return a safe generic internal error to the client; the full
+                    // exception is already captured in the server-side log above.
                     var errorResponse = JsonRpcSerializer.CreateErrorResponse(
                         request,
-                        JsonRpcErrorCodes.InternalError,
-                        ex.Message,
-                        _logger?.IsEnabled(LogLevel.Debug) == true ? ex.ToString() : null
+                        JsonRpcErrorCodes.InternalError
                     );
 
                     eventArgs.Response = errorResponse;
@@ -221,7 +221,8 @@ namespace Andy.Acp.Core.JsonRpc
             catch (JsonRpcProtocolException ex)
             {
                 _logger?.LogWarning(ex, "Protocol error in method: {Method}", request.Method);
-                return JsonRpcSerializer.CreateErrorResponse(request, ex.ErrorCode, ex.Message, ex.Data);
+                // ErrorData (not Exception.Data) is what belongs in error.data.
+                return JsonRpcSerializer.CreateErrorResponse(request, ex.ErrorCode, ex.Message, ex.ErrorData);
             }
             catch (ArgumentException ex)
             {
@@ -230,8 +231,10 @@ namespace Andy.Acp.Core.JsonRpc
             }
             catch (Exception ex)
             {
+                // Log full detail server-side but never leak internal exception
+                // messages or stack traces to the client.
                 _logger?.LogError(ex, "Method execution failed: {Method}", request.Method);
-                return JsonRpcSerializer.CreateErrorResponse(request, JsonRpcErrorCodes.InternalError, ex.Message);
+                return JsonRpcSerializer.CreateErrorResponse(request, JsonRpcErrorCodes.InternalError);
             }
         }
 
@@ -250,7 +253,8 @@ namespace Andy.Acp.Core.JsonRpc
             catch (JsonRpcProtocolException ex)
             {
                 _logger?.LogWarning(ex, "Protocol error in method: {Method}", request.Method);
-                return JsonRpcSerializer.CreateErrorResponse(request, ex.ErrorCode, ex.Message, ex.Data);
+                // ErrorData (not Exception.Data) is what belongs in error.data.
+                return JsonRpcSerializer.CreateErrorResponse(request, ex.ErrorCode, ex.Message, ex.ErrorData);
             }
             catch (ArgumentException ex)
             {
@@ -259,8 +263,10 @@ namespace Andy.Acp.Core.JsonRpc
             }
             catch (Exception ex)
             {
+                // Log full detail server-side but never leak internal exception
+                // messages or stack traces to the client.
                 _logger?.LogError(ex, "Method execution failed: {Method}", request.Method);
-                return JsonRpcSerializer.CreateErrorResponse(request, JsonRpcErrorCodes.InternalError, ex.Message);
+                return JsonRpcSerializer.CreateErrorResponse(request, JsonRpcErrorCodes.InternalError);
             }
         }
     }

--- a/src/Andy.Acp.Core/JsonRpc/JsonRpcMessage.cs
+++ b/src/Andy.Acp.Core/JsonRpc/JsonRpcMessage.cs
@@ -33,23 +33,45 @@ namespace Andy.Acp.Core.JsonRpc
         public object? Params { get; set; }
 
         /// <summary>
-        /// Request identifier. If present, this is a request that expects a response.
-        /// If null, this is a notification.
+        /// Request identifier. Per JSON-RPC 2.0 an absent id member denotes a
+        /// notification, while an explicitly present id (including <c>null</c>)
+        /// denotes a request that expects a response.
         /// </summary>
         [JsonPropertyName("id")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public object? Id { get; set; }
 
+        private bool? _hasId;
+
         /// <summary>
-        /// Gets a value indicating whether this is a notification (no response expected)
+        /// Whether an id member was present on the wire. Defaults to
+        /// <c>Id != null</c> for locally constructed messages, and is set
+        /// explicitly by the deserializer so that an explicit <c>id: null</c>
+        /// is distinguished from an omitted id (a notification).
         /// </summary>
         [JsonIgnore]
-        public bool IsNotification => Id == null;
+        public bool HasId
+        {
+            get => _hasId ?? (Id != null);
+            set => _hasId = value;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this is a notification (no response expected).
+        /// A notification is a message with no id member at all.
+        /// </summary>
+        [JsonIgnore]
+        public bool IsNotification => !HasId;
     }
 
     /// <summary>
-    /// Represents a JSON-RPC 2.0 response message
+    /// Represents a JSON-RPC 2.0 response message.
+    /// Serialization is handled by <see cref="JsonRpcResponseConverter"/> so that a
+    /// successful response always emits a <c>result</c> member (even when the value is
+    /// <c>null</c>), an error response emits only an <c>error</c> member, and the two
+    /// are mutually exclusive as required by JSON-RPC 2.0.
     /// </summary>
+    [JsonConverter(typeof(JsonRpcResponseConverter))]
     public class JsonRpcResponse : JsonRpcMessage
     {
         /// <summary>
@@ -62,7 +84,6 @@ namespace Andy.Acp.Core.JsonRpc
         /// Result of the method execution (present on success)
         /// </summary>
         [JsonPropertyName("result")]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public object? Result { get; set; }
 
         /// <summary>

--- a/src/Andy.Acp.Core/JsonRpc/JsonRpcResponseConverter.cs
+++ b/src/Andy.Acp.Core/JsonRpc/JsonRpcResponseConverter.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Andy.Acp.Core.JsonRpc
+{
+    /// <summary>
+    /// Custom converter for <see cref="JsonRpcResponse"/> that enforces the JSON-RPC 2.0
+    /// response contract independently of nullable values:
+    /// <list type="bullet">
+    /// <item>A successful response always writes a <c>result</c> member, even when the
+    /// result value is <c>null</c>.</item>
+    /// <item>An error response writes only an <c>error</c> member and never a <c>result</c>.</item>
+    /// <item><c>result</c> and <c>error</c> are mutually exclusive.</item>
+    /// <item>The <c>id</c> member is always written, including an explicit <c>null</c>.</item>
+    /// </list>
+    /// Success versus error is determined solely by whether <see cref="JsonRpcResponse.Error"/>
+    /// is set, so a successful <c>null</c> result round-trips correctly.
+    /// </summary>
+    public sealed class JsonRpcResponseConverter : JsonConverter<JsonRpcResponse>
+    {
+        public override JsonRpcResponse Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            using var document = JsonDocument.ParseValue(ref reader);
+            var root = document.RootElement;
+
+            object? id = null;
+            if (root.TryGetProperty("id", out var idElement))
+            {
+                id = ReadId(idElement);
+            }
+
+            JsonRpcError? error = null;
+            object? result = null;
+
+            if (root.TryGetProperty("error", out var errorElement) &&
+                errorElement.ValueKind != JsonValueKind.Null)
+            {
+                error = errorElement.Deserialize<JsonRpcError>(options);
+            }
+            else if (root.TryGetProperty("result", out var resultElement))
+            {
+                // Preserve the raw result payload so callers can deserialize it to a
+                // concrete type. A JsonValueKind.Null result is retained as null.
+                result = resultElement.ValueKind == JsonValueKind.Null
+                    ? null
+                    : resultElement.Clone();
+            }
+
+            return new JsonRpcResponse
+            {
+                Id = id,
+                Result = result,
+                Error = error
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, JsonRpcResponse value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteString("jsonrpc", value.JsonRpc);
+
+            writer.WritePropertyName("id");
+            WriteId(writer, value.Id);
+
+            if (value.Error != null)
+            {
+                writer.WritePropertyName("error");
+                JsonSerializer.Serialize(writer, value.Error, options);
+            }
+            else
+            {
+                // Success: always emit result, even when null.
+                writer.WritePropertyName("result");
+                if (value.Result == null)
+                {
+                    writer.WriteNullValue();
+                }
+                else
+                {
+                    JsonSerializer.Serialize(writer, value.Result, value.Result.GetType(), options);
+                }
+            }
+
+            writer.WriteEndObject();
+        }
+
+        private static object? ReadId(JsonElement idElement)
+        {
+            return idElement.ValueKind switch
+            {
+                JsonValueKind.String => idElement.GetString(),
+                JsonValueKind.Number => idElement.TryGetInt64(out var l) ? l : idElement.GetDouble(),
+                JsonValueKind.Null => null,
+                _ => idElement.Clone()
+            };
+        }
+
+        private static void WriteId(Utf8JsonWriter writer, object? id)
+        {
+            switch (id)
+            {
+                case null:
+                    writer.WriteNullValue();
+                    break;
+                case string s:
+                    writer.WriteStringValue(s);
+                    break;
+                case int i:
+                    writer.WriteNumberValue(i);
+                    break;
+                case long l:
+                    writer.WriteNumberValue(l);
+                    break;
+                case double d:
+                    writer.WriteNumberValue(d);
+                    break;
+                case JsonElement el:
+                    el.WriteTo(writer);
+                    break;
+                default:
+                    JsonSerializer.Serialize(writer, id, id.GetType());
+                    break;
+            }
+        }
+    }
+}

--- a/src/Andy.Acp.Core/JsonRpc/JsonRpcSerializer.cs
+++ b/src/Andy.Acp.Core/JsonRpc/JsonRpcSerializer.cs
@@ -63,6 +63,15 @@ namespace Andy.Acp.Core.JsonRpc
                 using var document = JsonDocument.Parse(json);
                 var root = document.RootElement;
 
+                // JSON-RPC batch requests (a top-level array) are not supported by this
+                // implementation. Reject them explicitly and consistently rather than
+                // failing with an opaque parse error.
+                if (root.ValueKind == JsonValueKind.Array)
+                    throw new JsonRpcInvalidRequestException("JSON-RPC batch requests are not supported");
+
+                if (root.ValueKind != JsonValueKind.Object)
+                    throw new JsonRpcInvalidRequestException("A JSON-RPC message must be a JSON object");
+
                 // Validate jsonrpc version
                 if (root.TryGetProperty("jsonrpc", out var jsonRpcElement))
                 {
@@ -112,6 +121,23 @@ namespace Andy.Acp.Core.JsonRpc
                     // Method names starting with "rpc." are reserved
                     if (request.Method.StartsWith("rpc.", StringComparison.OrdinalIgnoreCase))
                         throw new JsonRpcInvalidRequestException("Method names starting with 'rpc.' are reserved");
+
+                    // Distinguish an omitted id (notification) from an explicit id (including
+                    // an explicit null), which the JsonRpcRequest model cannot otherwise tell apart.
+                    request.HasId = hasId;
+                    if (hasId && root.TryGetProperty("id", out var idElement) &&
+                        idElement.ValueKind is JsonValueKind.Object or JsonValueKind.Array
+                            or JsonValueKind.True or JsonValueKind.False)
+                    {
+                        throw new JsonRpcInvalidRequestException("'id' must be a string, number, or null");
+                    }
+
+                    // Per JSON-RPC 2.0, 'params' (when present) must be a structured value.
+                    if (root.TryGetProperty("params", out var paramsElement) &&
+                        paramsElement.ValueKind is not (JsonValueKind.Object or JsonValueKind.Array or JsonValueKind.Null))
+                    {
+                        throw new JsonRpcInvalidRequestException("'params' must be an object or array");
+                    }
 
                     return request;
                 }

--- a/src/Andy.Acp.Core/Protocol/AcpSessionHandler.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpSessionHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -21,6 +22,11 @@ namespace Andy.Acp.Core.Protocol
         private readonly ILogger<AcpSessionHandler>? _logger;
         private readonly JsonRpcHandler _jsonRpcHandler;
         private ITransport? _transport;
+
+        // Tracks the in-flight prompt operation per session so that session/cancel
+        // can interrupt exactly the prompt it targets. At most one prompt per session
+        // is allowed to run concurrently.
+        private readonly ConcurrentDictionary<string, CancellationTokenSource> _activePrompts = new();
 
         public AcpSessionHandler(
             IAgentProvider agentProvider,
@@ -162,33 +168,56 @@ namespace Andy.Acp.Core.Protocol
                     promptParams.SessionId,
                     promptMessage.Text.Substring(0, Math.Min(50, promptMessage.Text.Length)));
 
-                // Create a response streamer that sends session/update notifications
-                var streamer = new SessionUpdateStreamer(_transport, promptParams.SessionId, _logger);
-
-                // Process the prompt through the agent
-                var response = await _agentProvider.ProcessPromptAsync(
-                    promptParams.SessionId,
-                    promptMessage,
-                    streamer,
-                    cancellationToken);
-
-                _logger?.LogInformation("Prompt processing completed for session {SessionId}, stop reason: {StopReason}",
-                    promptParams.SessionId, response.StopReason);
-
-                // Return only stopReason (ACP protocol expects only this field)
-                // The actual message content was already sent via session/update notifications
-                return new
+                // Link a per-prompt cancellation source to the connection token so that a
+                // session/cancel targeting this session cancels exactly this prompt.
+                var promptCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                if (!_activePrompts.TryAdd(promptParams.SessionId, promptCts))
                 {
-                    stopReason = MapStopReason(response.StopReason)
-                };
+                    promptCts.Dispose();
+                    throw new JsonRpcProtocolException(
+                        JsonRpcErrorCodes.InvalidRequest,
+                        $"A prompt is already in progress for session {promptParams.SessionId}");
+                }
+
+                try
+                {
+                    // Create a response streamer that sends session/update notifications
+                    var streamer = new SessionUpdateStreamer(_transport, promptParams.SessionId, _logger);
+
+                    // Process the prompt through the agent using the linked token.
+                    var response = await _agentProvider.ProcessPromptAsync(
+                        promptParams.SessionId,
+                        promptMessage,
+                        streamer,
+                        promptCts.Token);
+
+                    _logger?.LogInformation("Prompt processing completed for session {SessionId}, stop reason: {StopReason}",
+                        promptParams.SessionId, response.StopReason);
+
+                    // Return only stopReason. The message content was already streamed via
+                    // session/update notifications, which are written before this response.
+                    return new
+                    {
+                        stopReason = MapStopReason(response.StopReason)
+                    };
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger?.LogInformation("Prompt processing was cancelled for session {SessionId}", promptParams.SessionId);
+                    return new
+                    {
+                        stopReason = "cancelled"
+                    };
+                }
+                finally
+                {
+                    _activePrompts.TryRemove(promptParams.SessionId, out _);
+                    promptCts.Dispose();
+                }
             }
-            catch (OperationCanceledException)
+            catch (JsonRpcProtocolException)
             {
-                _logger?.LogInformation("Prompt processing was cancelled");
-                return new
-                {
-                    stopReason = "cancelled"
-                };
+                throw;
             }
             catch (Exception ex)
             {
@@ -277,7 +306,7 @@ namespace Andy.Acp.Core.Protocol
 
         private async Task<object?> HandleCancelAsync(object? parameters, CancellationToken cancellationToken)
         {
-            _logger?.LogDebug("Handling session/cancel request");
+            _logger?.LogDebug("Handling session/cancel notification");
 
             try
             {
@@ -290,15 +319,23 @@ namespace Andy.Acp.Core.Protocol
                         "Session ID is required");
                 }
 
+                // Cancel the in-flight prompt for this session, if any. Duplicate or late
+                // cancellations are harmless: there is simply no active prompt to cancel.
+                if (_activePrompts.TryGetValue(cancelParams.SessionId, out var promptCts))
+                {
+                    _logger?.LogInformation("Cancelling in-flight prompt for session {SessionId}", cancelParams.SessionId);
+                    try { promptCts.Cancel(); } catch (ObjectDisposedException) { }
+                }
+
+                // Also notify the agent so it can stop any session-scoped background work.
                 await _agentProvider.CancelSessionAsync(cancelParams.SessionId, cancellationToken);
 
-                _logger?.LogInformation("Cancelled session {SessionId}", cancelParams.SessionId);
-
-                return new { success = true };
+                // session/cancel is a notification; the server sends no response for it.
+                return null;
             }
             catch (Exception ex)
             {
-                _logger?.LogError(ex, "Error cancelling session");
+                _logger?.LogError(ex, "Error handling session/cancel");
                 throw;
             }
         }

--- a/src/Andy.Acp.Core/Server/AcpServer.cs
+++ b/src/Andy.Acp.Core/Server/AcpServer.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Concurrent;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -62,13 +64,31 @@ namespace Andy.Acp.Core.Server
         /// <param name="cancellationToken">Cancellation token to stop the server</param>
         public async Task RunAsync(CancellationToken cancellationToken = default)
         {
+            var transport = new StdioTransport(_loggerFactory?.CreateLogger<StdioTransport>());
+            try
+            {
+                await RunAsync(transport, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                transport.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Run the ACP server over the supplied transport. This overload exists so the
+        /// full server stack can be driven over an in-memory duplex transport in tests.
+        /// The caller owns the transport's lifetime.
+        /// </summary>
+        public async Task RunAsync(ITransport transport, CancellationToken cancellationToken = default)
+        {
+            if (transport == null)
+                throw new ArgumentNullException(nameof(transport));
+
             _logger?.LogInformation("Starting ACP server: {Name} v{Version}", _serverInfo.Name, _serverInfo.Version);
 
             try
             {
-                // Create transport layer (stdio)
-                var transport = new StdioTransport(_loggerFactory?.CreateLogger<StdioTransport>());
-
                 // Create JSON-RPC handler
                 var jsonRpcHandler = new JsonRpcHandler(_loggerFactory?.CreateLogger<JsonRpcHandler>());
 
@@ -167,13 +187,39 @@ namespace Andy.Acp.Core.Server
                     supportedMethods.Count(),
                     string.Join(", ", supportedMethods));
 
-                // Main server loop - read and process messages
-                while (!cancellationToken.IsCancellationRequested && transport.IsConnected)
+                // Main server loop. The transport read loop stays responsive while
+                // request handlers execute so that control messages (notably
+                // session/cancel) can be read and processed while a prompt is in flight.
+                var inFlight = new ConcurrentDictionary<Task, byte>();
+                try
                 {
-                    try
+                    while (!cancellationToken.IsCancellationRequested && transport.IsConnected)
                     {
-                        // Read message from transport
-                        var messageJson = await transport.ReadMessageAsync(cancellationToken);
+                        string messageJson;
+                        try
+                        {
+                            messageJson = await transport.ReadMessageAsync(cancellationToken);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            _logger?.LogInformation("Server read loop cancelled");
+                            break;
+                        }
+                        catch (EndOfStreamException)
+                        {
+                            _logger?.LogInformation("Input stream closed");
+                            break;
+                        }
+                        catch (Exception ex) when (ex.InnerException is EndOfStreamException)
+                        {
+                            _logger?.LogInformation("Input stream closed");
+                            break;
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger?.LogError(ex, "Error reading message; stopping read loop");
+                            break;
+                        }
 
                         if (string.IsNullOrEmpty(messageJson))
                         {
@@ -181,75 +227,39 @@ namespace Andy.Acp.Core.Server
                             break;
                         }
 
-                        _logger?.LogTrace("Received message: {MessageLength} bytes", messageJson.Length);
+                        // Dispatch handling without blocking the read loop. Failures are
+                        // observed in the continuation and never terminate the loop silently.
+                        var handlerTask = Task.Run(
+                            () => DispatchMessageAsync(messageJson, jsonRpcHandler, transport, cancellationToken),
+                            CancellationToken.None);
 
-                        // Deserialize and handle JSON-RPC message
-                        JsonRpcResponse? response = null;
-
-                        try
+                        inFlight.TryAdd(handlerTask, 0);
+                        _ = handlerTask.ContinueWith(t =>
                         {
-                            var jsonRpcMessage = JsonRpcSerializer.Deserialize(messageJson);
-
-                            if (jsonRpcMessage is JsonRpcRequest request)
-                            {
-                                _logger?.LogDebug("Processing request: {Method} (ID: {Id})", request.Method, request.Id);
-
-                                // Handle the request - session management is done by protocol handler
-                                response = await jsonRpcHandler.HandleRequestAsync(request, cancellationToken);
-                            }
-                            else if (jsonRpcMessage is JsonRpcResponse responseMessage)
-                            {
-                                _logger?.LogDebug("Received response (ID: {Id}), ignoring in server mode", responseMessage.Id);
-                            }
-                        }
-                        catch (JsonRpcException ex)
-                        {
-                            _logger?.LogWarning(ex, "JSON-RPC error: {Message}", ex.Message);
-
-                            // Create error response
-                            var errorCode = ex is JsonRpcParseException
-                                ? JsonRpcErrorCodes.ParseError
-                                : JsonRpcErrorCodes.InvalidRequest;
-
-                            response = JsonRpcSerializer.CreateErrorResponse(
-                                requestId: null,
-                                JsonRpcErrorCodes.CreateError(errorCode, ex.Message));
-                        }
-
-                        // Send response if we have one
-                        if (response != null)
-                        {
-                            var responseJson = JsonRpcSerializer.Serialize(response);
-                            await transport.WriteMessageAsync(responseJson, cancellationToken);
-                            _logger?.LogTrace("Sent response: {ResponseLength} bytes", responseJson.Length);
-                        }
+                            inFlight.TryRemove(t, out _);
+                            if (t.IsFaulted)
+                                _logger?.LogError(t.Exception, "Unhandled error in message handler");
+                        }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
                     }
-                    catch (OperationCanceledException)
+                }
+                finally
+                {
+                    // Allow in-flight handlers to flush their final updates/responses,
+                    // then clean up. Cleanup runs on a non-cancelled path so resources are
+                    // always released even when cancellation triggered the shutdown.
+                    try
                     {
-                        _logger?.LogInformation("Server cancelled");
-                        break;
-                    }
-                    catch (EndOfStreamException)
-                    {
-                        _logger?.LogInformation("Input stream closed");
-                        break;
+                        if (!inFlight.IsEmpty)
+                            await Task.WhenAll(inFlight.Keys).WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {
-                        _logger?.LogError(ex, "Error processing message");
-
-                        // If inner exception is EndOfStreamException, break
-                        if (ex.InnerException is EndOfStreamException)
-                        {
-                            _logger?.LogInformation("Input stream closed");
-                            break;
-                        }
+                        _logger?.LogWarning(ex, "Timed out or errored waiting for in-flight handlers during shutdown");
                     }
-                }
 
-                // Cleanup
-                await sessionManager.StopAsync(cancellationToken);
-                await transport.CloseAsync(cancellationToken);
+                    await sessionManager.StopAsync(CancellationToken.None);
+                    await transport.CloseAsync(CancellationToken.None);
+                }
 
                 _logger?.LogInformation("ACP server stopped");
             }
@@ -257,6 +267,68 @@ namespace Andy.Acp.Core.Server
             {
                 _logger?.LogError(ex, "Fatal error in ACP server");
                 throw;
+            }
+        }
+
+        /// <summary>
+        /// Deserializes a single inbound message, routes it through the JSON-RPC handler,
+        /// and writes any response. Ordering of a prompt's session/update notifications
+        /// relative to its final response is preserved because the streamer writes those
+        /// updates while <c>HandleRequestAsync</c> is awaited, before the response is written.
+        /// </summary>
+        private async Task DispatchMessageAsync(
+            string messageJson,
+            JsonRpcHandler jsonRpcHandler,
+            ITransport transport,
+            CancellationToken cancellationToken)
+        {
+            JsonRpcResponse? response = null;
+
+            try
+            {
+                var jsonRpcMessage = JsonRpcSerializer.Deserialize(messageJson);
+
+                if (jsonRpcMessage is JsonRpcRequest request)
+                {
+                    _logger?.LogDebug("Processing {Kind}: {Method} (ID: {Id})",
+                        request.IsNotification ? "notification" : "request", request.Method, request.Id);
+
+                    response = await jsonRpcHandler.HandleRequestAsync(request, cancellationToken).ConfigureAwait(false);
+                }
+                else if (jsonRpcMessage is JsonRpcResponse responseMessage)
+                {
+                    // Inbound responses correspond to agent-to-client requests. Routing them
+                    // to pending outbound operations is handled by the bidirectional layer.
+                    _logger?.LogDebug("Received response (ID: {Id}) with no pending outbound request", responseMessage.Id);
+                }
+            }
+            catch (JsonRpcException ex)
+            {
+                _logger?.LogWarning(ex, "JSON-RPC error: {Message}", ex.Message);
+                var errorCode = ex is JsonRpcParseException
+                    ? JsonRpcErrorCodes.ParseError
+                    : JsonRpcErrorCodes.InvalidRequest;
+                response = JsonRpcSerializer.CreateErrorResponse(
+                    requestId: null,
+                    JsonRpcErrorCodes.CreateError(errorCode, ex.Message));
+            }
+
+            if (response != null)
+            {
+                try
+                {
+                    var responseJson = JsonRpcSerializer.Serialize(response);
+                    await transport.WriteMessageAsync(responseJson, cancellationToken).ConfigureAwait(false);
+                    _logger?.LogTrace("Sent response: {ResponseLength} bytes", responseJson.Length);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Shutting down; nothing to write.
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Failed to write response");
+                }
             }
         }
     }

--- a/src/Andy.Acp.Core/Transport/StdioTransport.cs
+++ b/src/Andy.Acp.Core/Transport/StdioTransport.cs
@@ -8,99 +8,120 @@ using Microsoft.Extensions.Logging;
 namespace Andy.Acp.Core.Transport
 {
     /// <summary>
-    /// Transport implementation using standard input/output streams
+    /// The line/message framing used on a stdio connection.
+    /// </summary>
+    public enum StdioFramingMode
+    {
+        /// <summary>Newline-delimited JSON (Zed/Gemini style).</summary>
+        LineDelimited,
+
+        /// <summary>Content-Length header framing (LSP/MCP style).</summary>
+        ContentLength
+    }
+
+    /// <summary>
+    /// Transport implementation using standard input/output streams.
+    /// Framing is performed at the byte-stream layer so that raw UTF-8 payloads
+    /// round-trip exactly under Content-Length framing, and responses are written
+    /// using the same framing mode that was detected on input.
     /// </summary>
     public class StdioTransport : ITransport
     {
+        private const int DefaultMaxMessageSize = 64 * 1024 * 1024; // 64 MiB
+        private const int MaxHeaderLineLength = 8 * 1024;           // 8 KiB per header line
+        private const int MaxHeaderCount = 100;
+
         private readonly ILogger<StdioTransport>? _logger;
         private readonly Stream _inputStream;
         private readonly Stream _outputStream;
-        private readonly StreamReader _reader;
-        private readonly StreamWriter _writer;
         private readonly SemaphoreSlim _writeSemaphore = new(1, 1);
+        private readonly bool _ownsStreams;
+        private readonly string _lineTerminator;
+        private readonly long _maxMessageSize;
+
+        private readonly byte[] _buffer = new byte[8192];
+        private int _bufferPos;
+        private int _bufferLen;
+
+        // Framing mode used for outbound writes. Starts as line-delimited and is
+        // updated to match whatever framing is detected on the first inbound message.
+        private StdioFramingMode _framingMode = StdioFramingMode.LineDelimited;
+
+        private volatile bool _closed;
         private bool _disposed;
 
         /// <summary>
-        /// Initializes a new instance of the StdioTransport class with optional logger
+        /// Initializes a new instance using the process standard input/output streams.
         /// </summary>
-        /// <param name="logger">Optional logger instance</param>
-        public StdioTransport(ILogger<StdioTransport>? logger = null)
+        public StdioTransport(ILogger<StdioTransport>? logger = null, long maxMessageSize = DefaultMaxMessageSize)
         {
             _logger = logger;
-
-            // Use the raw stdin/stdout streams
             _inputStream = Console.OpenStandardInput();
             _outputStream = Console.OpenStandardOutput();
+            _ownsStreams = true;
+            _lineTerminator = "\n";
+            _maxMessageSize = maxMessageSize;
 
-            // Create our own readers/writers with explicit settings
-            _reader = new StreamReader(_inputStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
-            _writer = new StreamWriter(_outputStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), bufferSize: 1024, leaveOpen: true)
-            {
-                AutoFlush = true,
-                NewLine = "\n" // Use LF only, not CRLF
-            };
-
-            _logger?.LogDebug("StdioTransport initialized using stdin/stdout with custom readers");
+            _logger?.LogDebug("StdioTransport initialized using stdin/stdout (byte framing)");
         }
 
         /// <summary>
-        /// Initializes a new instance of the StdioTransport class with custom streams
+        /// Initializes a new instance using caller-provided streams. The caller retains
+        /// ownership of the streams and is responsible for disposing them.
         /// </summary>
-        /// <param name="inputStream">Input stream</param>
-        /// <param name="outputStream">Output stream</param>
-        /// <param name="logger">Optional logger instance</param>
-        public StdioTransport(Stream inputStream, Stream outputStream, ILogger<StdioTransport>? logger = null)
+        public StdioTransport(Stream inputStream, Stream outputStream, ILogger<StdioTransport>? logger = null, long maxMessageSize = DefaultMaxMessageSize)
         {
             _logger = logger;
             _inputStream = inputStream ?? throw new ArgumentNullException(nameof(inputStream));
             _outputStream = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
+            _ownsStreams = false;
+            _lineTerminator = "\r\n";
+            _maxMessageSize = maxMessageSize;
 
-            _reader = new StreamReader(_inputStream, Encoding.UTF8);
-            _writer = new StreamWriter(_outputStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))
-            {
-                AutoFlush = true,
-                NewLine = "\r\n" // Use CRLF for protocol compatibility
-            };
-
-            _logger?.LogDebug("StdioTransport initialized");
+            _logger?.LogDebug("StdioTransport initialized (byte framing)");
         }
 
+        /// <summary>
+        /// The framing mode currently used for outbound writes.
+        /// </summary>
+        public StdioFramingMode FramingMode => _framingMode;
+
         /// <inheritdoc />
-        public bool IsConnected => !_disposed && _inputStream.CanRead && _outputStream.CanWrite;
+        public bool IsConnected => !_disposed && !_closed && _inputStream.CanRead && _outputStream.CanWrite;
 
         /// <inheritdoc />
         public async Task<string> ReadMessageAsync(CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
+            cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
-                _logger?.LogTrace("Reading message from stdin");
+                // Read the first line. In line-delimited mode this is the whole message,
+                // so allow it to grow up to the maximum message size.
+                var firstLineBytes = await ReadLineBytesAsync(_maxMessageSize, cancellationToken).ConfigureAwait(false);
+                if (firstLineBytes == null)
+                    throw new EndOfStreamException("End of input stream");
 
-                // Read first line to detect format
-                string firstLine = await ReadLineAsync(cancellationToken);
+                var firstLine = Encoding.UTF8.GetString(firstLineBytes);
 
                 if (string.IsNullOrEmpty(firstLine))
-                {
                     throw new InvalidOperationException("Unexpected empty first line");
-                }
 
-                // Check if it's Content-Length header or line-delimited JSON
                 if (firstLine.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase))
                 {
-                    // Content-Length header format (LSP/MCP style)
-                    return await ReadContentLengthMessageAsync(firstLine, cancellationToken);
+                    _framingMode = StdioFramingMode.ContentLength;
+                    return await ReadContentLengthMessageAsync(firstLine, cancellationToken).ConfigureAwait(false);
                 }
-                else if (firstLine.TrimStart().StartsWith("{"))
+
+                if (firstLine.TrimStart().StartsWith("{") || firstLine.TrimStart().StartsWith("["))
                 {
-                    // Line-delimited JSON format (Zed/Gemini style)
-                    _logger?.LogTrace("Detected line-delimited JSON format");
+                    _framingMode = StdioFramingMode.LineDelimited;
+                    _logger?.LogTrace("Detected line-delimited JSON message");
                     return firstLine.Trim();
                 }
-                else
-                {
-                    throw new InvalidOperationException($"Unexpected message format. Line: {firstLine}");
-                }
+
+                throw new InvalidOperationException($"Unexpected message framing. Line: {firstLine}");
             }
             catch (OperationCanceledException)
             {
@@ -113,65 +134,48 @@ namespace Andy.Acp.Core.Transport
             }
             catch (Exception ex)
             {
-                _logger?.LogError(ex, "Error reading message from stdin");
+                _logger?.LogError(ex, "Error reading message from input");
                 throw;
             }
         }
 
-        /// <summary>
-        /// Reads a message using Content-Length header format
-        /// </summary>
         private async Task<string> ReadContentLengthMessageAsync(string firstLine, CancellationToken cancellationToken)
         {
-            int contentLength = -1;
-            string headerLine = firstLine;
+            int contentLength = ParseContentLength(firstLine);
 
-            // Parse Content-Length header
-            if (headerLine.StartsWith("Content-Length: ", StringComparison.OrdinalIgnoreCase))
-            {
-                if (!int.TryParse(headerLine.Substring(16), out contentLength) || contentLength < 0)
-                {
-                    throw new InvalidOperationException($"Invalid Content-Length value: {headerLine}");
-                }
-            }
-
-            // Read remaining headers until empty line
+            // Consume remaining headers until the blank line that separates headers from body.
+            int headerCount = 0;
             while (true)
             {
-                headerLine = await ReadLineAsync(cancellationToken);
+                var headerBytes = await ReadLineBytesAsync(MaxHeaderLineLength, cancellationToken).ConfigureAwait(false);
+                if (headerBytes == null)
+                    throw new EndOfStreamException("Unexpected end of stream while reading headers");
 
-                if (string.IsNullOrEmpty(headerLine))
-                {
-                    // Empty line indicates end of headers
-                    if (contentLength == -1)
-                    {
-                        throw new InvalidOperationException("Missing Content-Length header");
-                    }
-                    break;
-                }
+                if (headerBytes.Length == 0)
+                    break; // blank line -> end of headers
 
-                // Process other headers if needed
+                if (++headerCount > MaxHeaderCount)
+                    throw new InvalidOperationException("Too many headers");
             }
 
-            // Read message content
-            char[] buffer = new char[contentLength];
-            int totalRead = 0;
+            var body = await ReadExactBytesAsync(contentLength, cancellationToken).ConfigureAwait(false);
+            _logger?.LogTrace("Read Content-Length message of {Length} bytes", contentLength);
+            return Encoding.UTF8.GetString(body);
+        }
 
-            while (totalRead < contentLength)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                int bytesRead = await _reader.ReadAsync(buffer, totalRead, contentLength - totalRead);
-                if (bytesRead == 0)
-                {
-                    throw new InvalidOperationException("Unexpected end of stream while reading message content");
-                }
-                totalRead += bytesRead;
-            }
+        private int ParseContentLength(string headerLine)
+        {
+            int colon = headerLine.IndexOf(':');
+            var value = colon >= 0 ? headerLine.Substring(colon + 1).Trim() : string.Empty;
 
-            string message = new string(buffer);
-            _logger?.LogTrace("Successfully read Content-Length message of {Length} characters", contentLength);
+            if (!int.TryParse(value, out int contentLength) || contentLength < 0)
+                throw new InvalidOperationException($"Invalid Content-Length value: {headerLine}");
 
-            return message;
+            if (contentLength > _maxMessageSize)
+                throw new InvalidOperationException(
+                    $"Content-Length {contentLength} exceeds maximum message size {_maxMessageSize}");
+
+            return contentLength;
         }
 
         /// <inheritdoc />
@@ -184,22 +188,37 @@ namespace Andy.Acp.Core.Transport
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            await _writeSemaphore.WaitAsync(cancellationToken);
+            await _writeSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                _logger?.LogTrace("Writing message to stdout with {Length} characters", message.Length);
+                var payload = Encoding.UTF8.GetBytes(message);
+                byte[] frame;
 
-                // Write line-delimited JSON (simpler format, compatible with Zed/Gemini)
-                await _writer.WriteLineAsync(message);
-                await _writer.FlushAsync();
+                if (_framingMode == StdioFramingMode.ContentLength)
+                {
+                    var header = Encoding.ASCII.GetBytes($"Content-Length: {payload.Length}\r\n\r\n");
+                    frame = new byte[header.Length + payload.Length];
+                    Buffer.BlockCopy(header, 0, frame, 0, header.Length);
+                    Buffer.BlockCopy(payload, 0, frame, header.Length, payload.Length);
+                }
+                else
+                {
+                    var terminator = Encoding.ASCII.GetBytes(_lineTerminator);
+                    frame = new byte[payload.Length + terminator.Length];
+                    Buffer.BlockCopy(payload, 0, frame, 0, payload.Length);
+                    Buffer.BlockCopy(terminator, 0, frame, payload.Length, terminator.Length);
+                }
 
-                _logger?.LogTrace("Successfully wrote message");
+                await _outputStream.WriteAsync(frame.AsMemory(0, frame.Length), cancellationToken).ConfigureAwait(false);
+                await _outputStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+                _logger?.LogTrace("Wrote message ({Length} bytes, {Mode})", payload.Length, _framingMode);
             }
             catch (Exception ex) when (!(ex is OperationCanceledException))
             {
-                _logger?.LogError(ex, "Error writing message to stdout");
+                _logger?.LogError(ex, "Error writing message to output");
                 throw;
             }
             finally
@@ -211,18 +230,15 @@ namespace Andy.Acp.Core.Transport
         /// <inheritdoc />
         public async Task CloseAsync(CancellationToken cancellationToken = default)
         {
-            if (_disposed)
+            if (_closed || _disposed)
                 return;
 
+            _closed = true;
             try
             {
                 _logger?.LogDebug("Closing StdioTransport");
-
-                await _writer.FlushAsync();
-                _writer.Close();
-                _reader.Close();
-
-                _logger?.LogDebug("StdioTransport closed successfully");
+                // Flush any buffered output. Cleanup must not itself be cancelled.
+                await _outputStream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -231,66 +247,82 @@ namespace Andy.Acp.Core.Transport
         }
 
         /// <summary>
-        /// Reads a line from the input stream asynchronously
+        /// Reads one line of raw bytes terminated by <c>\n</c>. A single preceding
+        /// <c>\r</c> is stripped. Returns an empty array for a blank line and
+        /// <c>null</c> at end of stream (with no partial data buffered).
         /// </summary>
-        /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>The line read from the stream</returns>
-        private async Task<string> ReadLineAsync(CancellationToken cancellationToken)
+        private async Task<byte[]?> ReadLineBytesAsync(long maxLength, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Use standard ReadLineAsync for better compatibility with piped stdin
-            var line = await _reader.ReadLineAsync();
-
-            if (line == null)
+            using var ms = new MemoryStream();
+            while (true)
             {
-                throw new EndOfStreamException("Unexpected end of stream");
-            }
-
-            return line;
-        }
-
-        /// <summary>
-        /// Reads a single character from the input stream asynchronously
-        /// </summary>
-        /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>The character read, or -1 if end of stream</returns>
-        private async Task<int> ReadCharAsync(CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // For console stdin, we need to use a different approach since ReadAsync doesn't respect cancellation
-            var buffer = new char[1];
-            var readTask = _reader.ReadAsync(buffer, 0, 1);
-
-            // Create a delay task that completes when cancelled
-            var delayTask = Task.Delay(100, cancellationToken);
-
-            while (!readTask.IsCompleted)
-            {
-                var completedTask = await Task.WhenAny(readTask, delayTask);
-
-                if (completedTask == delayTask)
+                int b = await ReadRawByteAsync(cancellationToken).ConfigureAwait(false);
+                if (b < 0)
                 {
-                    // Cancellation was requested
-                    cancellationToken.ThrowIfCancellationRequested();
-                    // Create a new delay task for the next iteration
-                    delayTask = Task.Delay(100, cancellationToken);
+                    if (ms.Length == 0)
+                        return null; // clean EOF at a message boundary
+                    break;           // trailing line without newline
                 }
-                else
-                {
-                    // Read task completed
+
+                if (b == '\n')
                     break;
-                }
+
+                ms.WriteByte((byte)b);
+                if (ms.Length > maxLength)
+                    throw new InvalidOperationException($"Line exceeds maximum length of {maxLength} bytes");
             }
 
-            int result = await readTask;
-            return result == 0 ? -1 : buffer[0];
+            var arr = ms.ToArray();
+            int len = arr.Length;
+            if (len > 0 && arr[len - 1] == (byte)'\r')
+            {
+                Array.Resize(ref arr, len - 1);
+            }
+            return arr;
         }
 
         /// <summary>
-        /// Throws ObjectDisposedException if the transport has been disposed
+        /// Reads exactly <paramref name="count"/> bytes, draining the internal buffer
+        /// first and then reading from the underlying stream.
         /// </summary>
+        private async Task<byte[]> ReadExactBytesAsync(int count, CancellationToken cancellationToken)
+        {
+            var result = new byte[count];
+            int filled = 0;
+
+            while (filled < count && _bufferPos < _bufferLen)
+                result[filled++] = _buffer[_bufferPos++];
+
+            while (filled < count)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                int n = await _inputStream.ReadAsync(result.AsMemory(filled, count - filled), cancellationToken).ConfigureAwait(false);
+                if (n == 0)
+                    throw new EndOfStreamException("Unexpected end of stream while reading message content");
+                filled += n;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Reads a single byte from the buffered input, refilling from the underlying
+        /// stream as needed. The read observes the cancellation token so an idle read
+        /// can be aborted within a bounded time.
+        /// </summary>
+        private async ValueTask<int> ReadRawByteAsync(CancellationToken cancellationToken)
+        {
+            if (_bufferPos >= _bufferLen)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                _bufferLen = await _inputStream.ReadAsync(_buffer.AsMemory(0, _buffer.Length), cancellationToken).ConfigureAwait(false);
+                _bufferPos = 0;
+                if (_bufferLen == 0)
+                    return -1;
+            }
+            return _buffer[_bufferPos++];
+        }
+
         private void ThrowIfDisposed()
         {
             if (_disposed)
@@ -304,35 +336,32 @@ namespace Andy.Acp.Core.Transport
             GC.SuppressFinalize(this);
         }
 
-        /// <summary>
-        /// Disposes the transport resources
-        /// </summary>
-        /// <param name="disposing">True if disposing managed resources</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposed && disposing)
+            if (_disposed || !disposing)
+                return;
+
+            _logger?.LogDebug("Disposing StdioTransport");
+            _closed = true;
+
+            try
             {
-                _logger?.LogDebug("Disposing StdioTransport");
+                _writeSemaphore.Dispose();
 
-                try
+                // Only dispose streams we opened ourselves; caller-provided streams
+                // remain the caller's responsibility.
+                if (_ownsStreams)
                 {
-                    _writeSemaphore?.Dispose();
-                    _writer?.Dispose();
-                    _reader?.Dispose();
-
-                    // Only dispose streams if we don't own the standard streams
-                    if (_inputStream != Console.OpenStandardInput())
-                        _inputStream?.Dispose();
-                    if (_outputStream != Console.OpenStandardOutput())
-                        _outputStream?.Dispose();
+                    _inputStream.Dispose();
+                    _outputStream.Dispose();
                 }
-                catch (Exception ex)
-                {
-                    _logger?.LogWarning(ex, "Error occurred while disposing StdioTransport");
-                }
-
-                _disposed = true;
             }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Error occurred while disposing StdioTransport");
+            }
+
+            _disposed = true;
         }
     }
 }

--- a/src/Andy.Acp.Server/BundledEchoAgentProvider.cs
+++ b/src/Andy.Acp.Server/BundledEchoAgentProvider.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Agent;
+
+namespace Andy.Acp.Server
+{
+    /// <summary>
+    /// A minimal, self-contained <see cref="IAgentProvider"/> that echoes prompts back
+    /// as streamed agent message chunks. It makes the Andy.Acp.Server executable a
+    /// working ACP agent without any external model dependency.
+    /// </summary>
+    internal sealed class BundledEchoAgentProvider : IAgentProvider
+    {
+        private readonly ConcurrentDictionary<string, DateTime> _sessions = new();
+        private int _counter;
+
+        public Task<SessionMetadata> CreateSessionAsync(NewSessionParams? parameters, CancellationToken cancellationToken)
+        {
+            var sessionId = parameters?.SessionId ?? $"session-{Interlocked.Increment(ref _counter)}";
+            var now = DateTime.UtcNow;
+            _sessions[sessionId] = now;
+
+            return Task.FromResult(new SessionMetadata
+            {
+                SessionId = sessionId,
+                CreatedAt = now,
+                LastAccessedAt = now,
+                Mode = parameters?.Mode ?? "chat",
+                Model = parameters?.Model ?? "echo-v1",
+                MessageCount = 0
+            });
+        }
+
+        public Task<SessionMetadata?> LoadSessionAsync(string sessionId, CancellationToken cancellationToken)
+        {
+            if (_sessions.TryGetValue(sessionId, out var createdAt))
+            {
+                return Task.FromResult<SessionMetadata?>(new SessionMetadata
+                {
+                    SessionId = sessionId,
+                    CreatedAt = createdAt,
+                    LastAccessedAt = DateTime.UtcNow,
+                    Mode = "chat",
+                    Model = "echo-v1"
+                });
+            }
+
+            return Task.FromResult<SessionMetadata?>(null);
+        }
+
+        public async Task<AgentResponse> ProcessPromptAsync(
+            string sessionId,
+            PromptMessage prompt,
+            IResponseStreamer streamer,
+            CancellationToken cancellationToken)
+        {
+            var responseText = $"Echo: {prompt.Text}";
+
+            foreach (var word in responseText.Split(' '))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await streamer.SendMessageChunkAsync(word + " ", cancellationToken);
+            }
+
+            return new AgentResponse
+            {
+                Message = responseText,
+                StopReason = StopReason.Completed
+            };
+        }
+
+        public Task CancelSessionAsync(string sessionId, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task<bool> SetSessionModeAsync(string sessionId, string mode, CancellationToken cancellationToken)
+            => Task.FromResult(_sessions.ContainsKey(sessionId));
+
+        public Task<bool> SetSessionModelAsync(string sessionId, string model, CancellationToken cancellationToken)
+            => Task.FromResult(_sessions.ContainsKey(sessionId));
+
+        public AgentCapabilities GetCapabilities() => new()
+        {
+            LoadSession = true
+        };
+    }
+}

--- a/src/Andy.Acp.Server/Program.cs
+++ b/src/Andy.Acp.Server/Program.cs
@@ -1,42 +1,45 @@
 using System;
-using System.CommandLine;
-using System.Text.Json;
+using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Andy.Acp.Core.Protocol;
+using Andy.Acp.Core.Server;
 using Microsoft.Extensions.Logging;
-using Andy.Acp.Core.Transport;
 
 namespace Andy.Acp.Server
 {
-    class Program
+    /// <summary>
+    /// Entry point for the Andy ACP server executable. It hosts the real
+    /// <see cref="AcpServer"/> stack over stdio with a bundled echo agent so the
+    /// binary is a working, self-contained ACP agent out of the box.
+    /// </summary>
+    internal static class Program
     {
-        static async Task<int> Main(string[] args)
+        private static async Task<int> Main(string[] args)
         {
-            bool acpServerMode = false;
             bool verbose = false;
             string? logFile = null;
 
-            // Parse command line arguments
             for (int i = 0; i < args.Length; i++)
             {
                 switch (args[i])
                 {
                     case "--acp-server":
-                        acpServerMode = true;
+                        // Retained for backward compatibility; stdio server mode is the
+                        // only mode this executable runs.
                         break;
                     case "--verbose":
+                    case "-v":
                         verbose = true;
                         break;
                     case "--log-file":
-                        if (i + 1 < args.Length)
-                        {
-                            logFile = args[++i];
-                        }
-                        else
+                        if (i + 1 >= args.Length)
                         {
                             Console.Error.WriteLine("Error: --log-file requires a file path");
                             return 1;
                         }
+                        logFile = args[++i];
                         break;
                     case "--help":
                     case "-h":
@@ -49,133 +52,87 @@ namespace Andy.Acp.Server
                 }
             }
 
-            if (!acpServerMode)
-            {
-                Console.WriteLine("Andy ACP Server");
-                Console.WriteLine("Use --acp-server to start in ACP mode");
-                ShowHelp();
-                return 0;
-            }
-
             try
             {
-                await RunAcpServerAsync(verbose, logFile);
-                return 0;
+                return await RunAsync(verbose, logFile);
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"Error: {ex.Message}");
+                Console.Error.WriteLine($"Fatal: {ex.Message}");
                 return 1;
             }
         }
 
-        static void ShowHelp()
+        private static void ShowHelp()
         {
-            Console.WriteLine();
-            Console.WriteLine("Usage: Andy.Acp.Server [options]");
-            Console.WriteLine();
-            Console.WriteLine("Options:");
-            Console.WriteLine("  --acp-server         Start in ACP server mode");
-            Console.WriteLine("  --verbose           Enable verbose logging");
-            Console.WriteLine("  --log-file <path>   Log to file instead of stderr");
-            Console.WriteLine("  --help, -h          Show this help message");
-            Console.WriteLine();
-            Console.WriteLine("Examples:");
-            Console.WriteLine("  Andy.Acp.Server --acp-server");
-            Console.WriteLine("  Andy.Acp.Server --acp-server --verbose");
-            Console.WriteLine("  Andy.Acp.Server --acp-server --log-file /path/to/log.txt");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Andy ACP Server - an Agent Client Protocol agent over stdio");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Usage: Andy.Acp.Server [options]");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Options:");
+            Console.Error.WriteLine("  --acp-server        Run as an ACP stdio server (default behavior)");
+            Console.Error.WriteLine("  --verbose, -v       Enable debug-level logging");
+            Console.Error.WriteLine("  --log-file <path>   Write diagnostics to a file instead of stderr");
+            Console.Error.WriteLine("  --help, -h          Show this help message");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Diagnostics are written to stderr (or --log-file); stdout carries only");
+            Console.Error.WriteLine("the JSON-RPC/ACP protocol stream.");
         }
 
-        static async Task RunAcpServerAsync(bool verbose, string? logFile)
+        private static async Task<int> RunAsync(bool verbose, string? logFile)
         {
-            // Set up logging
-            using var loggerFactory = LoggerFactory.Create(builder =>
-            {
-                if (verbose)
-                {
-                    builder.SetMinimumLevel(LogLevel.Debug);
-                }
-                else
-                {
-                    builder.SetMinimumLevel(LogLevel.Information);
-                }
-
-                // In ACP mode, console logging goes to stderr
-                builder.AddSimpleConsole(options =>
-                {
-                    options.SingleLine = true;
-                    options.TimestampFormat = "HH:mm:ss ";
-                });
-            });
-
-            var logger = loggerFactory.CreateLogger<Program>();
-            var transportLogger = loggerFactory.CreateLogger<StdioTransport>();
-
-            // Redirect console output to stderr when in ACP mode
-            Console.SetOut(Console.Error);
-
-            using var transport = new StdioTransport(transportLogger);
-
-            logger.LogInformation("Andy ACP Server starting...");
-            logger.LogInformation("Listening for ACP messages on stdin");
-
-            var cancellationTokenSource = new CancellationTokenSource();
-
-            // Handle Ctrl+C gracefully
-            Console.CancelKeyPress += (sender, e) =>
-            {
-                e.Cancel = true;
-                logger.LogInformation("Shutdown requested...");
-                cancellationTokenSource.Cancel();
-            };
-
+            StreamWriter? fileWriter = null;
             try
             {
-                while (!cancellationTokenSource.Token.IsCancellationRequested && transport.IsConnected)
+                using var loggerFactory = LoggerFactory.Create(builder =>
                 {
-                    try
+                    builder.SetMinimumLevel(verbose ? LogLevel.Debug : LogLevel.Information);
+
+                    // Diagnostics must never touch stdout, which is the protocol channel.
+                    if (logFile != null)
                     {
-                        logger.LogDebug("Waiting for incoming message...");
-
-                        var message = await transport.ReadMessageAsync(cancellationTokenSource.Token);
-
-                        logger.LogInformation("Received message: {MessageLength} characters", message.Length);
-                        logger.LogDebug("Message content: {Message}", message);
-
-                        // Echo the message back for now (placeholder for actual ACP message handling)
-                        var response = $"{{\"id\":null,\"result\":{{\"echo\":\"{message}\"}},\"jsonrpc\":\"2.0\"}}";
-
-                        await transport.WriteMessageAsync(response, cancellationTokenSource.Token);
-
-                        logger.LogDebug("Response sent");
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        break;
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogError(ex, "Error processing message");
-
-                        // Send error response
-                        var errorResponse = $"{{\"id\":null,\"error\":{{\"code\":-32603,\"message\":\"Internal error: {ex.Message}\"}},\"jsonrpc\":\"2.0\"}}";
-
-                        try
+                        fileWriter = new StreamWriter(
+                            new FileStream(logFile, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
                         {
-                            await transport.WriteMessageAsync(errorResponse, cancellationTokenSource.Token);
-                        }
-                        catch (Exception writeEx)
-                        {
-                            logger.LogError(writeEx, "Failed to send error response");
-                        }
+                            AutoFlush = true
+                        };
+                        builder.AddProvider(new TextWriterLoggerProvider(fileWriter));
                     }
-                }
+                    else
+                    {
+                        builder.AddProvider(new TextWriterLoggerProvider(Console.Error));
+                    }
+                });
+
+                // Redirect any stray Console.Out writes to stderr so they cannot corrupt
+                // the protocol stream (the transport uses the raw stdout handle directly).
+                Console.SetOut(Console.Error);
+
+                var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0.0.0";
+                var serverInfo = new ServerInfo
+                {
+                    Name = "Andy ACP Server",
+                    Version = version,
+                    Description = "Andy Agent Client Protocol server (bundled echo agent)"
+                };
+
+                var agent = new BundledEchoAgentProvider();
+                var server = new AcpServer(agent, serverInfo: serverInfo, loggerFactory: loggerFactory);
+
+                using var cts = new CancellationTokenSource();
+                Console.CancelKeyPress += (_, e) =>
+                {
+                    e.Cancel = true;
+                    cts.Cancel();
+                };
+
+                await server.RunAsync(cts.Token);
+                return 0;
             }
             finally
             {
-                logger.LogInformation("Closing transport...");
-                await transport.CloseAsync();
-                logger.LogInformation("Andy ACP Server stopped");
+                fileWriter?.Dispose();
             }
         }
     }

--- a/src/Andy.Acp.Server/TextWriterLoggerProvider.cs
+++ b/src/Andy.Acp.Server/TextWriterLoggerProvider.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Acp.Server
+{
+    /// <summary>
+    /// Minimal <see cref="ILoggerProvider"/> that writes single-line, timestamped log
+    /// entries to a supplied <see cref="TextWriter"/> (stderr or a log file). Keeping
+    /// this dependency-free guarantees that no diagnostics are ever written to stdout,
+    /// which is reserved for the ACP protocol stream.
+    /// </summary>
+    internal sealed class TextWriterLoggerProvider : ILoggerProvider
+    {
+        private readonly TextWriter _writer;
+        private readonly object _gate = new();
+
+        public TextWriterLoggerProvider(TextWriter writer)
+        {
+            _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        }
+
+        public ILogger CreateLogger(string categoryName) => new TextWriterLogger(this, categoryName);
+
+        public void Dispose()
+        {
+            // The provider does not own stderr; a file writer is disposed by the caller.
+        }
+
+        private void Write(string line)
+        {
+            lock (_gate)
+            {
+                _writer.WriteLine(line);
+            }
+        }
+
+        private sealed class TextWriterLogger : ILogger
+        {
+            private readonly TextWriterLoggerProvider _provider;
+            private readonly string _category;
+
+            public TextWriterLogger(TextWriterLoggerProvider provider, string category)
+            {
+                _provider = provider;
+                _category = category;
+            }
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (!IsEnabled(logLevel))
+                    return;
+
+                var message = formatter(state, exception);
+                var shortCategory = _category.Substring(_category.LastIndexOf('.') + 1);
+                var line = $"{DateTime.Now:HH:mm:ss} [{Short(logLevel)}] {shortCategory}: {message}";
+                _provider.Write(line);
+
+                if (exception != null)
+                    _provider.Write(exception.ToString());
+            }
+
+            private static string Short(LogLevel level) => level switch
+            {
+                LogLevel.Trace => "trce",
+                LogLevel.Debug => "dbug",
+                LogLevel.Information => "info",
+                LogLevel.Warning => "warn",
+                LogLevel.Error => "fail",
+                LogLevel.Critical => "crit",
+                _ => "none"
+            };
+        }
+    }
+}

--- a/tests/Andy.Acp.Tests/JsonRpc/JsonRpcComplianceTests.cs
+++ b/tests/Andy.Acp.Tests/JsonRpc/JsonRpcComplianceTests.cs
@@ -1,0 +1,139 @@
+using System.Text.Json;
+using System.Threading.Tasks;
+using Andy.Acp.Core.JsonRpc;
+using Xunit;
+
+namespace Andy.Acp.Tests.JsonRpc
+{
+    /// <summary>
+    /// Tests for the normative JSON-RPC 2.0 rules addressed by issue #15:
+    /// null results, explicit null ids, error.data, batch rejection, and
+    /// notification handling.
+    /// </summary>
+    public class JsonRpcComplianceTests
+    {
+        [Fact]
+        public void Serialize_SuccessWithNullResult_IncludesResultMember()
+        {
+            var response = new JsonRpcResponse { Id = 1, Result = null };
+
+            var json = JsonRpcSerializer.Serialize(response);
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.True(doc.RootElement.TryGetProperty("result", out var result));
+            Assert.Equal(JsonValueKind.Null, result.ValueKind);
+            Assert.False(doc.RootElement.TryGetProperty("error", out _));
+        }
+
+        [Fact]
+        public void Serialize_ErrorResponse_OmitsResultMember()
+        {
+            var response = new JsonRpcResponse
+            {
+                Id = 1,
+                Error = new JsonRpcError { Code = JsonRpcErrorCodes.MethodNotFound, Message = "Method not found" }
+            };
+
+            var json = JsonRpcSerializer.Serialize(response);
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.False(doc.RootElement.TryGetProperty("result", out _));
+            Assert.True(doc.RootElement.TryGetProperty("error", out _));
+        }
+
+        [Fact]
+        public void Deserialize_ExplicitNullId_IsRequestNotNotification()
+        {
+            var json = """{"jsonrpc":"2.0","method":"ping","id":null}""";
+
+            var message = JsonRpcSerializer.Deserialize(json);
+
+            var request = Assert.IsType<JsonRpcRequest>(message);
+            Assert.True(request.HasId);
+            Assert.False(request.IsNotification);
+        }
+
+        [Fact]
+        public void Deserialize_OmittedId_IsNotification()
+        {
+            var json = """{"jsonrpc":"2.0","method":"ping"}""";
+
+            var message = JsonRpcSerializer.Deserialize(json);
+
+            var request = Assert.IsType<JsonRpcRequest>(message);
+            Assert.False(request.HasId);
+            Assert.True(request.IsNotification);
+        }
+
+        [Fact]
+        public void Serialize_ResponseWithNullId_WritesIdNull()
+        {
+            var response = new JsonRpcResponse { Id = null, Result = "ok" };
+
+            var json = JsonRpcSerializer.Serialize(response);
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.True(doc.RootElement.TryGetProperty("id", out var id));
+            Assert.Equal(JsonValueKind.Null, id.ValueKind);
+        }
+
+        [Fact]
+        public void ErrorData_RoundTripsThroughErrorMember()
+        {
+            var data = new { detail = "extra" };
+            var response = JsonRpcSerializer.CreateErrorResponse(
+                new JsonRpcRequest { Method = "m", Id = 7 },
+                JsonRpcErrorCodes.CreateError(JsonRpcErrorCodes.InvalidParams, "bad", data));
+
+            var json = JsonRpcSerializer.Serialize(response);
+
+            using var doc = JsonDocument.Parse(json);
+            var error = doc.RootElement.GetProperty("error");
+            Assert.Equal("extra", error.GetProperty("data").GetProperty("detail").GetString());
+        }
+
+        [Fact]
+        public async Task ProtocolException_ErrorData_ReachesResponse()
+        {
+            var handler = new JsonRpcHandler();
+            handler.RegisterMethod("boom", (p, ct) =>
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "nope", new { field = "x" }));
+
+            var response = await handler.HandleRequestAsync(new JsonRpcRequest { Method = "boom", Id = 1 });
+
+            Assert.NotNull(response);
+            Assert.NotNull(response!.Error!.Data);
+            var json = JsonRpcSerializer.Serialize(response);
+            Assert.Contains("\"field\"", json);
+        }
+
+        [Fact]
+        public void Deserialize_BatchArray_IsRejected()
+        {
+            var json = """[{"jsonrpc":"2.0","method":"a","id":1},{"jsonrpc":"2.0","method":"b","id":2}]""";
+
+            Assert.Throws<JsonRpcInvalidRequestException>(() => JsonRpcSerializer.Deserialize(json));
+        }
+
+        [Fact]
+        public void Deserialize_PrimitiveParams_IsRejected()
+        {
+            var json = """{"jsonrpc":"2.0","method":"m","params":42,"id":1}""";
+
+            Assert.Throws<JsonRpcInvalidRequestException>(() => JsonRpcSerializer.Deserialize(json));
+        }
+
+        [Fact]
+        public async Task HandleRequest_Notification_ReturnsNull()
+        {
+            var handler = new JsonRpcHandler();
+            handler.RegisterMethod("note", (p, ct) => Task.FromResult<object?>("ignored"));
+
+            // A notification has no id member.
+            var request = new JsonRpcRequest { Method = "note", HasId = false };
+            var response = await handler.HandleRequestAsync(request);
+
+            Assert.Null(response);
+        }
+    }
+}

--- a/tests/Andy.Acp.Tests/JsonRpc/JsonRpcHandlerTests.cs
+++ b/tests/Andy.Acp.Tests/JsonRpc/JsonRpcHandlerTests.cs
@@ -90,7 +90,10 @@ namespace Andy.Acp.Tests.JsonRpc
             Assert.NotNull(response);
             Assert.True(response.IsError);
             Assert.Equal(JsonRpcErrorCodes.InternalError, response.Error!.Code);
-            Assert.Contains("Test error", response.Error.Message);
+            // Internal exception details must not leak to the client.
+            Assert.DoesNotContain("Test error", response.Error.Message);
+            Assert.Equal("Internal error", response.Error.Message);
+            Assert.Null(response.Error.Data);
         }
 
         [Fact]

--- a/tests/Andy.Acp.Tests/JsonRpc/JsonRpcSerializerTests.cs
+++ b/tests/Andy.Acp.Tests/JsonRpc/JsonRpcSerializerTests.cs
@@ -122,7 +122,8 @@ namespace Andy.Acp.Tests.JsonRpc
         public void Deserialize_ValidNotification_ReturnsNotification()
         {
             // Arrange
-            var json = """{"jsonrpc":"2.0","method":"notify","params":"test"}""";
+            // params must be a structured value (object or array) per JSON-RPC 2.0.
+            var json = """{"jsonrpc":"2.0","method":"notify","params":{"value":"test"}}""";
 
             // Act
             var message = JsonRpcSerializer.Deserialize(json);
@@ -147,7 +148,7 @@ namespace Andy.Acp.Tests.JsonRpc
             // Assert
             Assert.IsType<JsonRpcResponse>(message);
             var response = (JsonRpcResponse)message;
-            Assert.Equal("test", ((JsonElement)response.Id!).GetString());
+            Assert.Equal("test", response.Id);
             Assert.True(response.IsSuccess);
             Assert.False(response.IsError);
         }

--- a/tests/Andy.Acp.Tests/Server/AcpServerCancellationTests.cs
+++ b/tests/Andy.Acp.Tests/Server/AcpServerCancellationTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Agent;
+using Andy.Acp.Core.Server;
+using Xunit;
+
+namespace Andy.Acp.Tests.Server
+{
+    /// <summary>
+    /// End-to-end cancellation tests for issue #19: session/cancel must interrupt an
+    /// in-flight prompt promptly and produce a cancelled prompt result.
+    /// </summary>
+    public class AcpServerCancellationTests
+    {
+        [Fact]
+        public async Task SessionCancel_InterruptsInFlightPrompt_Promptly()
+        {
+            var harness = new InMemoryDuplex();
+            var agent = new BlockingAgent();
+            var server = new AcpServer(agent);
+
+            using var serverCts = new CancellationTokenSource();
+            var serverTask = server.RunAsync(harness.ServerTransport, serverCts.Token);
+
+            // Create a session.
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":1,"method":"session/new","params":{}}""");
+            var newDoc = JsonDocument.Parse(await harness.ReadMessageAsync());
+            var sessionId = newDoc.RootElement.GetProperty("result").GetProperty("sessionId").GetString();
+            Assert.False(string.IsNullOrEmpty(sessionId));
+
+            // Start a prompt that blocks until cancelled.
+            await harness.SendAsync(
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/prompt\",\"params\":{\"sessionId\":\"" +
+                sessionId + "\",\"prompt\":[{\"type\":\"text\",\"text\":\"hello\"}]}}");
+
+            Assert.True(await agent.Started.Task.WaitAsync(TimeSpan.FromSeconds(5)), "prompt did not start");
+
+            // Cancel it via a notification (no id).
+            var sw = Stopwatch.StartNew();
+            await harness.SendAsync(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"session/cancel\",\"params\":{\"sessionId\":\"" +
+                sessionId + "\"}}");
+
+            // The prompt (id=2) should complete promptly with a cancelled stop reason.
+            var promptResponse = await ReadUntilIdAsync(harness, 2, TimeSpan.FromSeconds(5));
+            sw.Stop();
+
+            Assert.Equal("cancelled", promptResponse.RootElement.GetProperty("result").GetProperty("stopReason").GetString());
+            Assert.True(sw.ElapsedMilliseconds < 5000, $"cancellation took too long: {sw.ElapsedMilliseconds}ms");
+
+            serverCts.Cancel();
+            harness.Complete();
+            try { await serverTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* shutdown races are fine */ }
+        }
+
+        [Fact]
+        public async Task SessionCancel_ForUnknownSession_IsHarmless()
+        {
+            var harness = new InMemoryDuplex();
+            var agent = new BlockingAgent();
+            var server = new AcpServer(agent);
+
+            using var serverCts = new CancellationTokenSource();
+            var serverTask = server.RunAsync(harness.ServerTransport, serverCts.Token);
+
+            // Cancel with no active prompt: must not throw or produce a response.
+            await harness.SendAsync("""{"jsonrpc":"2.0","method":"session/cancel","params":{"sessionId":"nope"}}""");
+
+            // A subsequent normal request still works.
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":9,"method":"session/new","params":{}}""");
+            var doc = await ReadUntilIdAsync(harness, 9, TimeSpan.FromSeconds(5));
+            Assert.True(doc.RootElement.GetProperty("result").TryGetProperty("sessionId", out _));
+
+            serverCts.Cancel();
+            harness.Complete();
+            try { await serverTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
+        }
+
+        private static async Task<JsonDocument> ReadUntilIdAsync(InMemoryDuplex harness, long id, TimeSpan timeout)
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            while (true)
+            {
+                var message = await harness.ReadMessageAsync(cts.Token);
+                if (string.IsNullOrEmpty(message))
+                    throw new InvalidOperationException("stream closed before expected response");
+
+                var doc = JsonDocument.Parse(message);
+                if (doc.RootElement.TryGetProperty("id", out var idEl) &&
+                    idEl.ValueKind == JsonValueKind.Number && idEl.GetInt64() == id)
+                {
+                    return doc;
+                }
+            }
+        }
+
+        /// <summary>An agent whose prompt blocks until the cancellation token fires.</summary>
+        private sealed class BlockingAgent : IAgentProvider
+        {
+            public readonly TaskCompletionSource<bool> Started =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public Task<SessionMetadata> CreateSessionAsync(NewSessionParams? parameters, CancellationToken cancellationToken)
+                => Task.FromResult(new SessionMetadata
+                {
+                    SessionId = "s1",
+                    CreatedAt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    Mode = "chat",
+                    Model = "test"
+                });
+
+            public Task<SessionMetadata?> LoadSessionAsync(string sessionId, CancellationToken cancellationToken)
+                => Task.FromResult<SessionMetadata?>(null);
+
+            public async Task<AgentResponse> ProcessPromptAsync(
+                string sessionId, PromptMessage prompt, IResponseStreamer streamer, CancellationToken cancellationToken)
+            {
+                Started.TrySetResult(true);
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+                return new AgentResponse { StopReason = StopReason.Completed };
+            }
+
+            public Task CancelSessionAsync(string sessionId, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task<bool> SetSessionModeAsync(string sessionId, string mode, CancellationToken cancellationToken) => Task.FromResult(true);
+            public Task<bool> SetSessionModelAsync(string sessionId, string model, CancellationToken cancellationToken) => Task.FromResult(true);
+            public AgentCapabilities GetCapabilities() => new();
+        }
+    }
+}

--- a/tests/Andy.Acp.Tests/Server/InMemoryDuplex.cs
+++ b/tests/Andy.Acp.Tests/Server/InMemoryDuplex.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Transport;
+
+namespace Andy.Acp.Tests.Server
+{
+    /// <summary>
+    /// An in-memory, bidirectional stdio harness. The server side is exposed as an
+    /// <see cref="ITransport"/>; the client side sends line-delimited JSON messages and
+    /// reads framed responses. Used to drive the full AcpServer stack in tests.
+    /// </summary>
+    internal sealed class InMemoryDuplex
+    {
+        private readonly InMemoryPipeStream _clientToServer = new();
+        private readonly InMemoryPipeStream _serverToClient = new();
+
+        public ITransport ServerTransport { get; }
+
+        public InMemoryDuplex()
+        {
+            // Server reads client->server and writes server->client.
+            ServerTransport = new StdioTransport(_clientToServer, _serverToClient);
+        }
+
+        /// <summary>Sends a raw JSON message from the client (newline-delimited framing).</summary>
+        public async Task SendAsync(string json)
+        {
+            var bytes = Encoding.UTF8.GetBytes(json + "\n");
+            await _clientToServer.WriteAsync(bytes, 0, bytes.Length);
+        }
+
+        /// <summary>Reads the next newline-delimited message written by the server.</summary>
+        public async Task<string> ReadMessageAsync(CancellationToken cancellationToken = default)
+        {
+            using var ms = new MemoryStream();
+            var one = new byte[1];
+            while (true)
+            {
+                int n = await _serverToClient.ReadAsync(one.AsMemory(0, 1), cancellationToken);
+                if (n == 0)
+                    break;
+                if (one[0] == (byte)'\n')
+                    break;
+                ms.WriteByte(one[0]);
+            }
+
+            var text = Encoding.UTF8.GetString(ms.ToArray());
+            return text.TrimEnd('\r');
+        }
+
+        public void Complete()
+        {
+            _clientToServer.CompleteWriting();
+            _serverToClient.CompleteWriting();
+        }
+    }
+
+    /// <summary>
+    /// A one-directional in-memory stream: one side writes, the other reads. Reads block
+    /// (asynchronously) until data is available, EOF (writer completed), or cancellation.
+    /// </summary>
+    internal sealed class InMemoryPipeStream : Stream
+    {
+        private readonly Channel<byte[]> _channel = Channel.CreateUnbounded<byte[]>();
+        private byte[]? _current;
+        private int _pos;
+
+        public override bool CanRead => true;
+        public override bool CanWrite => true;
+        public override bool CanSeek => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => 0; set { } }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (_current == null || _pos >= _current.Length)
+            {
+                if (!await _channel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+                    return 0; // writer completed and drained
+                _channel.Reader.TryRead(out _current);
+                _pos = 0;
+            }
+
+            if (_current == null)
+                return 0;
+
+            int count = Math.Min(buffer.Length, _current.Length - _pos);
+            _current.AsSpan(_pos, count).CopyTo(buffer.Span);
+            _pos += count;
+            return count;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => ReadAsync(buffer, offset, count, default).GetAwaiter().GetResult();
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            _channel.Writer.TryWrite(buffer.ToArray());
+            return ValueTask.CompletedTask;
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            var copy = new byte[count];
+            Array.Copy(buffer, offset, copy, 0, count);
+            _channel.Writer.TryWrite(copy);
+        }
+
+        public void CompleteWriting() => _channel.Writer.TryComplete();
+
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+    }
+}

--- a/tests/Andy.Acp.Tests/Transport/StdioFramingTests.cs
+++ b/tests/Andy.Acp.Tests/Transport/StdioFramingTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Transport;
+using Xunit;
+
+namespace Andy.Acp.Tests.Transport
+{
+    /// <summary>
+    /// Byte-framing, framing-mode, cancellation, and size-limit tests for issue #18.
+    /// </summary>
+    public class StdioFramingTests
+    {
+        [Fact]
+        public async Task RawUtf8ContentLength_RoundTripsExactly()
+        {
+            // Body contains unescaped multi-byte UTF-8 characters. Byte-accurate framing
+            // is required; a char-count read would truncate the trailing bytes.
+            var body = "{\"m\":\"世界 🌍 café\"}";
+            var bodyBytes = Encoding.UTF8.GetBytes(body);
+            var frame = Encoding.ASCII.GetBytes($"Content-Length: {bodyBytes.Length}\r\n\r\n");
+
+            var input = new MemoryStream();
+            input.Write(frame, 0, frame.Length);
+            input.Write(bodyBytes, 0, bodyBytes.Length);
+            input.Position = 0;
+
+            var transport = new StdioTransport(input, new MemoryStream());
+            var result = await transport.ReadMessageAsync(CancellationToken.None);
+
+            Assert.Equal(body, result);
+        }
+
+        [Fact]
+        public async Task MultipleAdjacentFramedMessages_ReadWithoutCorruption()
+        {
+            var m1 = "{\"a\":\"föö\"}";
+            var m2 = "{\"b\":\"世界\"}";
+            var b1 = Encoding.UTF8.GetBytes(m1);
+            var b2 = Encoding.UTF8.GetBytes(m2);
+
+            using var input = new MemoryStream();
+            void WriteFrame(byte[] body)
+            {
+                var h = Encoding.ASCII.GetBytes($"Content-Length: {body.Length}\r\n\r\n");
+                input.Write(h, 0, h.Length);
+                input.Write(body, 0, body.Length);
+            }
+            WriteFrame(b1);
+            WriteFrame(b2);
+            input.Position = 0;
+
+            var transport = new StdioTransport(input, new MemoryStream());
+            Assert.Equal(m1, await transport.ReadMessageAsync(CancellationToken.None));
+            Assert.Equal(m2, await transport.ReadMessageAsync(CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task ResponseFramingMatchesDetectedContentLengthMode()
+        {
+            var body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"x\"}";
+            var bodyBytes = Encoding.UTF8.GetBytes(body);
+            var frame = Encoding.ASCII.GetBytes($"Content-Length: {bodyBytes.Length}\r\n\r\n");
+
+            var input = new MemoryStream();
+            input.Write(frame, 0, frame.Length);
+            input.Write(bodyBytes, 0, bodyBytes.Length);
+            input.Position = 0;
+            var output = new MemoryStream();
+
+            var transport = new StdioTransport(input, output);
+            await transport.ReadMessageAsync(CancellationToken.None);
+            Assert.Equal(StdioFramingMode.ContentLength, transport.FramingMode);
+
+            await transport.WriteMessageAsync("{\"ok\":true}", CancellationToken.None);
+
+            var written = Encoding.UTF8.GetString(output.ToArray());
+            Assert.StartsWith("Content-Length: 11\r\n\r\n", written);
+            Assert.EndsWith("{\"ok\":true}", written);
+        }
+
+        [Fact]
+        public async Task IdleCancellation_StopsWithinBoundedTime()
+        {
+            var transport = new StdioTransport(new BlockingStream(), new MemoryStream());
+            using var cts = new CancellationTokenSource();
+
+            var readTask = transport.ReadMessageAsync(cts.Token);
+            cts.CancelAfter(200);
+
+            var sw = Stopwatch.StartNew();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => readTask);
+            sw.Stop();
+
+            Assert.True(sw.ElapsedMilliseconds < 5000, $"Cancellation took too long: {sw.ElapsedMilliseconds}ms");
+        }
+
+        [Fact]
+        public async Task OversizedContentLength_IsRejected()
+        {
+            var frame = Encoding.ASCII.GetBytes("Content-Length: 1000000\r\n\r\n");
+            var input = new MemoryStream(frame);
+
+            // maxMessageSize below the advertised Content-Length -> reject before allocating.
+            var transport = new StdioTransport(input, new MemoryStream(), maxMessageSize: 1024);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                transport.ReadMessageAsync(CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task OversizedLineDelimitedMessage_IsRejected()
+        {
+            var big = "{\"data\":\"" + new string('x', 5000) + "\"}\n";
+            var input = new MemoryStream(Encoding.UTF8.GetBytes(big));
+
+            var transport = new StdioTransport(input, new MemoryStream(), maxMessageSize: 1024);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                transport.ReadMessageAsync(CancellationToken.None));
+        }
+
+        /// <summary>
+        /// A stream whose reads block until the cancellation token fires, used to
+        /// simulate an idle stdin.
+        /// </summary>
+        private sealed class BlockingStream : Stream
+        {
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => 0; set { } }
+
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+                return 0;
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override void Flush() { }
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
Foundation work for the ACP v1 conformance epic (#10). These are the transport, JSON-RPC, and runtime-lifecycle fixes that are independent of the wire-model changes, landed first as a reviewable increment. The wire-model epics (#12/#13/#14/#16) and tests/docs (#21/#17) follow in separate PRs.

## Closes
- #15 — JSON-RPC null/id/error-data/batch compliance
- #18 — stdio byte framing, cancellation, shutdown
- #19 — in-flight session cancellation
- #20 — real Andy.Acp.Server executable

## #15 JSON-RPC compliance
- Successful `null` results serialize with an explicit `result: null` (new `JsonRpcResponseConverter`) instead of dropping the member.
- Distinguish an omitted request id (notification) from an explicit `id: null` (new `JsonRpcRequest.HasId`).
- `JsonRpcProtocolException.ErrorData` now lands in `error.data` (was mistakenly `Exception.Data`).
- Internal errors return a safe generic message to the client; full detail stays in server logs.
- Batch arrays are rejected explicitly and `params` is validated as a structured value.

## #18 stdio byte framing
- Byte-accurate `Content-Length` framing — raw UTF-8 payloads round-trip exactly (previously read as chars, corrupting multi-byte content).
- Detected framing mode is tracked and responses are written in the same mode.
- Cancellation-aware byte reads; an idle stdin aborts within a bounded time.
- Correct owns-streams disposal and guaranteed cleanup; max header/message size limits.

## #19 in-flight cancellation
- The read loop stays responsive while handlers run, so `session/cancel` is processed while a prompt is in flight.
- Per-session linked cancellation cancels exactly the targeted prompt and returns a `cancelled` stop reason; `session/update` ordering before the final response is preserved.
- Added `AcpServer.RunAsync(ITransport)` seam and an in-memory duplex transport harness for end-to-end tests.

## #20 real server executable
- Replaces the string-interpolation placeholder with a host for the real `AcpServer` + a bundled echo agent: uses `JsonRpcSerializer`, preserves ids, routes the ACP method set, returns method-not-found for unknown methods, and sends diagnostics to stderr/`--log-file` only (stdout is protocol-only).

## Verification
- All **257** unit tests pass (239 pre-existing + 18 new).
- Smoke-tested the `Andy.Acp.Server` binary: valid `initialize` + `session/new` exchange, unknown method → `-32601` with original id, notifications receive no response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)