### PR TITLE
fix: schema-valid session/update + preserved prompt content blocks (#14, #16 partial)

### DIFF
--- a/src/Andy.Acp.Core/Agent/AgentModels.cs
+++ b/src/Andy.Acp.Core/Agent/AgentModels.cs
@@ -4,34 +4,95 @@ using System.Collections.Generic;
 namespace Andy.Acp.Core.Agent
 {
     /// <summary>
-    /// A message from the user to the agent
+    /// A message from the user to the agent. The canonical representation is
+    /// <see cref="Blocks"/>, which preserves every ACP content block (text, image,
+    /// audio, resource, resource_link) in order. <see cref="Text"/> is a convenience
+    /// join of the text blocks and may be empty for a valid non-text prompt.
     /// </summary>
     public class PromptMessage
     {
         /// <summary>
-        /// The text content of the message
+        /// The ordered ACP content blocks that make up this prompt. This is the
+        /// lossless representation: image/audio/resource/resource_link payloads are
+        /// preserved here even when they have no text.
+        /// </summary>
+        public List<ContentBlock> Blocks { get; set; } = new();
+
+        /// <summary>
+        /// Convenience concatenation of the text blocks (newline-joined). May be empty
+        /// when the prompt contains only non-text content.
         /// </summary>
         public string Text { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Optional image attachments (URLs or base64)
-        /// </summary>
-        public List<ImageAttachment>? Images { get; set; }
-
-        /// <summary>
-        /// Optional audio attachments
-        /// </summary>
-        public List<AudioAttachment>? Audio { get; set; }
-
-        /// <summary>
-        /// Optional embedded context (file contents, etc.)
-        /// </summary>
-        public List<ContextItem>? Context { get; set; }
 
         /// <summary>
         /// Additional metadata
         /// </summary>
         public Dictionary<string, object>? Metadata { get; set; }
+    }
+
+    /// <summary>
+    /// An ACP content block. A single flexible shape covers every variant; the
+    /// populated fields depend on <see cref="Type"/>:
+    /// <list type="bullet">
+    /// <item><c>text</c>: <see cref="Text"/></item>
+    /// <item><c>image</c>/<c>audio</c>: <see cref="Data"/> (base64) + <see cref="MimeType"/></item>
+    /// <item><c>resource_link</c>: <see cref="Uri"/> + <see cref="Name"/> (+ optional metadata)</item>
+    /// <item><c>resource</c>: <see cref="Resource"/> (embedded text or blob)</item>
+    /// </list>
+    /// </summary>
+    public class ContentBlock
+    {
+        /// <summary>Discriminator: text, image, audio, resource_link, or resource.</summary>
+        public string Type { get; set; } = "text";
+
+        /// <summary>Text payload (type = text).</summary>
+        public string? Text { get; set; }
+
+        /// <summary>Base64-encoded payload (type = image or audio).</summary>
+        public string? Data { get; set; }
+
+        /// <summary>MIME type (image/audio/resource_link).</summary>
+        public string? MimeType { get; set; }
+
+        /// <summary>URI (resource_link, or optional source uri for image).</summary>
+        public string? Uri { get; set; }
+
+        /// <summary>Human-readable name (resource_link).</summary>
+        public string? Name { get; set; }
+
+        /// <summary>Optional description (resource_link).</summary>
+        public string? Description { get; set; }
+
+        /// <summary>Optional title (resource_link).</summary>
+        public string? Title { get; set; }
+
+        /// <summary>Optional size in bytes (resource_link).</summary>
+        public long? Size { get; set; }
+
+        /// <summary>Embedded resource contents (type = resource).</summary>
+        public EmbeddedResource? Resource { get; set; }
+
+        /// <summary>Optional ACP annotations, preserved as raw JSON.</summary>
+        public object? Annotations { get; set; }
+    }
+
+    /// <summary>
+    /// Embedded resource contents for a <c>resource</c> content block: either text
+    /// (<see cref="Text"/>) or binary (<see cref="Blob"/>, base64).
+    /// </summary>
+    public class EmbeddedResource
+    {
+        /// <summary>Resource URI.</summary>
+        public string? Uri { get; set; }
+
+        /// <summary>MIME type of the resource.</summary>
+        public string? MimeType { get; set; }
+
+        /// <summary>Text contents (TextResourceContents).</summary>
+        public string? Text { get; set; }
+
+        /// <summary>Base64 binary contents (BlobResourceContents).</summary>
+        public string? Blob { get; set; }
     }
 
     /// <summary>

--- a/src/Andy.Acp.Core/Agent/IResponseStreamer.cs
+++ b/src/Andy.Acp.Core/Agent/IResponseStreamer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -47,22 +48,38 @@ namespace Andy.Acp.Core.Agent
     }
 
     /// <summary>
-    /// Information about a tool call
+    /// Information about a tool call. Maps to the ACP <c>tool_call</c> session update.
     /// </summary>
     public class ToolCall
     {
         /// <summary>
-        /// Unique identifier for this tool call
+        /// Unique identifier for this tool call (ACP <c>toolCallId</c>).
         /// </summary>
         public string Id { get; set; } = string.Empty;
 
         /// <summary>
-        /// Name of the tool being called
+        /// Name of the tool being called. Used as the <c>title</c> when <see cref="Title"/> is not set.
         /// </summary>
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
-        /// Input parameters for the tool
+        /// Human-readable title for the call. Falls back to <see cref="Name"/> when null.
+        /// </summary>
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// ACP tool kind: read, edit, delete, move, search, execute, think, fetch,
+        /// switch_mode, or other. Defaults to "other".
+        /// </summary>
+        public string Kind { get; set; } = "other";
+
+        /// <summary>
+        /// ACP tool call status: pending, in_progress, completed, or failed. Defaults to "pending".
+        /// </summary>
+        public string Status { get; set; } = "pending";
+
+        /// <summary>
+        /// Raw input parameters for the tool (ACP <c>rawInput</c>).
         /// </summary>
         public object? Input { get; set; }
     }
@@ -89,18 +106,58 @@ namespace Andy.Acp.Core.Agent
     }
 
     /// <summary>
-    /// An execution plan describing what the agent intends to do
+    /// An execution plan describing what the agent intends to do. Maps to the ACP
+    /// <c>plan</c> session update, whose entries each carry a priority and status.
     /// </summary>
     public class ExecutionPlan
     {
         /// <summary>
-        /// Description of the plan
+        /// Description of the plan (informational; not part of the ACP plan wire shape).
         /// </summary>
         public string Description { get; set; } = string.Empty;
 
         /// <summary>
-        /// Steps in the plan
+        /// Optional simple step descriptions. When <see cref="Entries"/> is not set, each
+        /// step is mapped to a plan entry with medium priority and pending status.
         /// </summary>
         public string[]? Steps { get; set; }
+
+        /// <summary>
+        /// Structured plan entries. Preferred over <see cref="Steps"/>.
+        /// </summary>
+        public List<PlanEntry>? Entries { get; set; }
+
+        /// <summary>
+        /// Returns the effective, schema-valid plan entries, deriving them from
+        /// <see cref="Steps"/> when <see cref="Entries"/> is not provided.
+        /// </summary>
+        public List<PlanEntry> ResolveEntries()
+        {
+            if (Entries != null && Entries.Count > 0)
+                return Entries;
+
+            var derived = new List<PlanEntry>();
+            if (Steps != null)
+            {
+                foreach (var step in Steps)
+                    derived.Add(new PlanEntry { Content = step });
+            }
+            return derived;
+        }
+    }
+
+    /// <summary>
+    /// A single entry in an execution plan (ACP <c>PlanEntry</c>).
+    /// </summary>
+    public class PlanEntry
+    {
+        /// <summary>Human-readable description of the plan item.</summary>
+        public string Content { get; set; } = string.Empty;
+
+        /// <summary>Priority: high, medium, or low. Defaults to "medium".</summary>
+        public string Priority { get; set; } = "medium";
+
+        /// <summary>Status: pending, in_progress, or completed. Defaults to "pending".</summary>
+        public string Status { get; set; } = "pending";
     }
 }

--- a/src/Andy.Acp.Core/Protocol/AcpSessionHandler.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpSessionHandler.cs
@@ -154,19 +154,16 @@ namespace Andy.Acp.Core.Protocol
                         "Prompt content is required");
                 }
 
-                // Convert content blocks to PromptMessage
+                // Validate content types against the agent's negotiated capabilities.
+                // text and resource_link are baseline-supported; image/audio/embedded
+                // resource are gated on capabilities. Non-text prompts are permitted.
+                ValidateContentBlocks(promptParams.PromptBlocks);
+
+                // Convert content blocks to PromptMessage without losing non-text content.
                 var promptMessage = promptParams.ToPromptMessage();
 
-                if (string.IsNullOrEmpty(promptMessage.Text))
-                {
-                    throw new JsonRpcProtocolException(
-                        JsonRpcErrorCodes.InvalidParams,
-                        "Prompt text is required");
-                }
-
-                _logger?.LogInformation("Processing prompt for session {SessionId}: {PromptPreview}",
-                    promptParams.SessionId,
-                    promptMessage.Text.Substring(0, Math.Min(50, promptMessage.Text.Length)));
+                _logger?.LogInformation("Processing prompt for session {SessionId}: {BlockCount} block(s)",
+                    promptParams.SessionId, promptParams.PromptBlocks.Count);
 
                 // Link a per-prompt cancellation source to the connection token so that a
                 // session/cancel targeting this session cancels exactly this prompt.
@@ -345,13 +342,15 @@ namespace Andy.Acp.Core.Protocol
             if (parameters == null)
                 return null;
 
+            // Use the shared JSON-RPC options (camelCase, case-insensitive) so ACP wire
+            // field names bind correctly across every parameter type.
             if (parameters is JsonElement jsonElement)
             {
-                return JsonSerializer.Deserialize<T>(jsonElement.GetRawText());
+                return JsonSerializer.Deserialize<T>(jsonElement.GetRawText(), JsonRpcSerializer.Options);
             }
 
-            var json = JsonSerializer.Serialize(parameters);
-            return JsonSerializer.Deserialize<T>(json);
+            var json = JsonSerializer.Serialize(parameters, JsonRpcSerializer.Options);
+            return JsonSerializer.Deserialize<T>(json, JsonRpcSerializer.Options);
         }
 
         /// <summary>
@@ -377,6 +376,46 @@ namespace Andy.Acp.Core.Protocol
             public string SessionId { get; set; } = string.Empty;
         }
 
+        /// <summary>
+        /// Validates every prompt content block against the agent's negotiated
+        /// capabilities. text and resource_link are always accepted; image, audio, and
+        /// embedded resource content require the corresponding capability. Unsupported or
+        /// unknown content produces an InvalidParams error.
+        /// </summary>
+        private void ValidateContentBlocks(List<ContentBlock> blocks)
+        {
+            var caps = _agentProvider.GetCapabilities();
+
+            foreach (var block in blocks)
+            {
+                switch (block.Type)
+                {
+                    case "text":
+                    case "resource_link":
+                        // Baseline-supported regardless of capabilities.
+                        break;
+                    case "image":
+                        if (!caps.ImagePrompts)
+                            throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                                "Image content is not supported by this agent");
+                        break;
+                    case "audio":
+                        if (!caps.AudioPrompts)
+                            throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                                "Audio content is not supported by this agent");
+                        break;
+                    case "resource":
+                        if (!caps.EmbeddedContext)
+                            throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                                "Embedded resource content is not supported by this agent");
+                        break;
+                    default:
+                        throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                            $"Unsupported content block type: {block.Type}");
+                }
+            }
+        }
+
         private class PromptRequest
         {
             [JsonPropertyName("sessionId")]
@@ -385,7 +424,11 @@ namespace Andy.Acp.Core.Protocol
             [JsonPropertyName("prompt")]
             public List<ContentBlock>? PromptBlocks { get; set; }
 
-            // Helper to convert to PromptMessage
+            /// <summary>
+            /// Converts the request to a <see cref="PromptMessage"/> without discarding
+            /// non-text content: all blocks are preserved in order, and the text blocks
+            /// are additionally joined into <see cref="PromptMessage.Text"/>.
+            /// </summary>
             public PromptMessage ToPromptMessage()
             {
                 var message = new PromptMessage();
@@ -393,30 +436,15 @@ namespace Andy.Acp.Core.Protocol
                 if (PromptBlocks == null || PromptBlocks.Count == 0)
                     return message;
 
-                // Combine all text blocks
+                message.Blocks = PromptBlocks;
+
                 var textParts = PromptBlocks
                     .Where(b => b.Type == "text" && !string.IsNullOrEmpty(b.Text))
                     .Select(b => b.Text!);
-
                 message.Text = string.Join("\n", textParts);
 
                 return message;
             }
-        }
-
-        private class ContentBlock
-        {
-            [JsonPropertyName("type")]
-            public string Type { get; set; } = string.Empty;
-
-            [JsonPropertyName("text")]
-            public string? Text { get; set; }
-
-            [JsonPropertyName("data")]
-            public string? Data { get; set; }
-
-            [JsonPropertyName("mimeType")]
-            public string? MimeType { get; set; }
         }
 
         private class SetModeRequest

--- a/src/Andy.Acp.Core/Protocol/SessionUpdateStreamer.cs
+++ b/src/Andy.Acp.Core/Protocol/SessionUpdateStreamer.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Text.Json;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Andy.Acp.Core.Agent;
@@ -10,8 +10,20 @@ using Microsoft.Extensions.Logging;
 namespace Andy.Acp.Core.Protocol
 {
     /// <summary>
-    /// Implementation of IResponseStreamer that sends session/update notifications
-    /// to the client as the agent generates responses.
+    /// Implementation of <see cref="IResponseStreamer"/> that sends ACP v1
+    /// <c>session/update</c> notifications as the agent generates a response.
+    /// <para>
+    /// Every notification has the shape
+    /// <c>{ "jsonrpc":"2.0", "method":"session/update",
+    ///      "params": { "sessionId": ..., "update": { "sessionUpdate": &lt;variant&gt;, ... } } }</c>
+    /// where <c>update.sessionUpdate</c> selects a schema-defined variant.
+    /// </para>
+    /// <para>
+    /// Write-failure behavior: cancellation (<see cref="OperationCanceledException"/>) always
+    /// propagates so an in-flight prompt stops promptly. Other transport write failures are
+    /// logged and rethrown, because a broken connection makes further streaming pointless and
+    /// the agent should observe the failure rather than continue silently.
+    /// </para>
     /// </summary>
     public class SessionUpdateStreamer : IResponseStreamer
     {
@@ -29,139 +41,110 @@ namespace Andy.Acp.Core.Protocol
             _logger = logger;
         }
 
-        public async Task SendMessageChunkAsync(string text, CancellationToken cancellationToken)
+        public Task SendMessageChunkAsync(string text, CancellationToken cancellationToken)
         {
-            try
+            return SendUpdateAsync(new
             {
-                await SendNotificationAsync(new
-                {
-                    sessionId = _sessionId,
-                    update = new
-                    {
-                        content = new
-                        {
-                            type = "text",
-                            text
-                        },
-                        sessionUpdate = "agent_message_chunk"
-                    }
-                }, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning(ex, "Failed to send message chunk notification");
-            }
+                sessionUpdate = "agent_message_chunk",
+                content = new { type = "text", text }
+            }, cancellationToken);
         }
 
-        public async Task SendToolCallAsync(ToolCall toolCall, CancellationToken cancellationToken)
+        public Task SendThinkingAsync(string thinking, CancellationToken cancellationToken)
         {
-            try
+            return SendUpdateAsync(new
             {
-                await SendNotificationAsync(new
-                {
-                    sessionId = _sessionId,
-                    type = "tool_call",
-                    data = new
-                    {
-                        id = toolCall.Id,
-                        name = toolCall.Name,
-                        input = toolCall.Input
-                    }
-                }, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning(ex, "Failed to send tool call notification");
-            }
+                sessionUpdate = "agent_thought_chunk",
+                content = new { type = "text", text = thinking }
+            }, cancellationToken);
         }
 
-        public async Task SendToolResultAsync(ToolResult result, CancellationToken cancellationToken)
+        public Task SendToolCallAsync(ToolCall toolCall, CancellationToken cancellationToken)
         {
-            try
+            return SendUpdateAsync(new
             {
-                await SendNotificationAsync(new
-                {
-                    sessionId = _sessionId,
-                    type = "tool_result",
-                    data = new
-                    {
-                        callId = result.CallId,
-                        isError = result.IsError,
-                        content = result.Content
-                    }
-                }, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning(ex, "Failed to send tool result notification");
-            }
+                sessionUpdate = "tool_call",
+                toolCallId = toolCall.Id,
+                title = string.IsNullOrEmpty(toolCall.Title) ? toolCall.Name : toolCall.Title,
+                kind = string.IsNullOrEmpty(toolCall.Kind) ? "other" : toolCall.Kind,
+                status = string.IsNullOrEmpty(toolCall.Status) ? "pending" : toolCall.Status,
+                rawInput = toolCall.Input
+            }, cancellationToken);
         }
 
-        public async Task SendThinkingAsync(string thinking, CancellationToken cancellationToken)
+        public Task SendToolResultAsync(ToolResult result, CancellationToken cancellationToken)
         {
-            try
-            {
-                await SendNotificationAsync(new
+            object? content = result.Content == null
+                ? null
+                : new object[]
                 {
-                    sessionId = _sessionId,
-                    type = "thinking",
-                    data = new { text = thinking }
-                }, cancellationToken);
-            }
-            catch (Exception ex)
+                    new { type = "content", content = new { type = "text", text = result.Content } }
+                };
+
+            return SendUpdateAsync(new
             {
-                _logger?.LogWarning(ex, "Failed to send thinking notification");
-            }
+                sessionUpdate = "tool_call_update",
+                toolCallId = result.CallId,
+                status = result.IsError ? "failed" : "completed",
+                content
+            }, cancellationToken);
         }
 
-        public async Task SendExecutionPlanAsync(ExecutionPlan plan, CancellationToken cancellationToken)
+        public Task SendExecutionPlanAsync(ExecutionPlan plan, CancellationToken cancellationToken)
         {
-            try
+            var entries = plan.ResolveEntries().Select(e => new
             {
-                await SendNotificationAsync(new
-                {
-                    sessionId = _sessionId,
-                    type = "execution_plan",
-                    data = new
-                    {
-                        description = plan.Description,
-                        steps = plan.Steps
-                    }
-                }, cancellationToken);
-            }
-            catch (Exception ex)
+                content = e.Content,
+                priority = string.IsNullOrEmpty(e.Priority) ? "medium" : e.Priority,
+                status = string.IsNullOrEmpty(e.Status) ? "pending" : e.Status
+            }).ToArray();
+
+            return SendUpdateAsync(new
             {
-                _logger?.LogWarning(ex, "Failed to send execution plan notification");
-            }
+                sessionUpdate = "plan",
+                entries
+            }, cancellationToken);
         }
 
-        private async Task SendNotificationAsync(object data, CancellationToken cancellationToken)
+        /// <summary>
+        /// Wraps a session-update variant in the ACP notification envelope and writes it.
+        /// The <paramref name="update"/> object must already include a valid
+        /// <c>sessionUpdate</c> discriminator.
+        /// </summary>
+        private async Task SendUpdateAsync(object update, CancellationToken cancellationToken)
         {
             if (_transport == null)
             {
-                _logger?.LogWarning("Transport not set, cannot send session/update notification");
+                _logger?.LogWarning("Transport not set; dropping session/update notification");
                 return;
             }
 
+            var notification = new
+            {
+                jsonrpc = "2.0",
+                method = "session/update",
+                @params = new
+                {
+                    sessionId = _sessionId,
+                    update
+                }
+            };
+
+            var json = System.Text.Json.JsonSerializer.Serialize(notification, JsonRpcSerializer.Options);
+            _logger?.LogTrace("Sending session/update: {Notification}", json);
+
             try
             {
-                // Create JSON-RPC notification (no id means it's a notification, not a request)
-                var notification = new
-                {
-                    jsonrpc = "2.0",
-                    method = "session/update",
-                    @params = data
-                };
-
-                var notificationJson = JsonSerializer.Serialize(notification);
-
-                _logger?.LogTrace("Sending session/update notification: {Notification}", notificationJson);
-
-                await _transport.WriteMessageAsync(notificationJson, cancellationToken);
+                await _transport.WriteMessageAsync(json, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {
-                _logger?.LogError(ex, "Failed to send session/update notification");
+                _logger?.LogWarning(ex, "Failed to write session/update notification");
+                throw;
             }
         }
     }

--- a/tests/Andy.Acp.Tests/Protocol/ContentBlockPromptTests.cs
+++ b/tests/Andy.Acp.Tests/Protocol/ContentBlockPromptTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Agent;
+using Andy.Acp.Core.JsonRpc;
+using Andy.Acp.Core.Protocol;
+using Xunit;
+
+namespace Andy.Acp.Tests.Protocol
+{
+    /// <summary>
+    /// Tests that prompt content blocks are preserved and validated against
+    /// capabilities, and that non-text prompts are supported (issue #16).
+    /// </summary>
+    public class ContentBlockPromptTests
+    {
+        private static (JsonRpcHandler handler, CapturingAgent agent) Setup(AgentCapabilities caps)
+        {
+            var handler = new JsonRpcHandler();
+            var agent = new CapturingAgent { Caps = caps };
+            var sessionHandler = new AcpSessionHandler(agent, handler);
+            sessionHandler.RegisterMethods();
+            return (handler, agent);
+        }
+
+        private static JsonRpcRequest Prompt(string promptArrayJson)
+        {
+            var json = "{\"sessionId\":\"s1\",\"prompt\":" + promptArrayJson + "}";
+            var el = JsonDocument.Parse(json).RootElement.Clone();
+            return new JsonRpcRequest { Method = "session/prompt", Id = 1, Params = el };
+        }
+
+        [Fact]
+        public async Task MixedTextAndImage_PreservesAllBlocks()
+        {
+            var (handler, agent) = Setup(new AgentCapabilities { ImagePrompts = true });
+
+            var resp = await handler.HandleRequestAsync(Prompt(
+                "[{\"type\":\"text\",\"text\":\"hi\"},{\"type\":\"image\",\"data\":\"AAAA\",\"mimeType\":\"image/png\"}]"));
+
+            Assert.True(resp!.IsSuccess);
+            Assert.NotNull(agent.Received);
+            Assert.Equal(2, agent.Received!.Blocks.Count);
+            Assert.Equal("text", agent.Received.Blocks[0].Type);
+            Assert.Equal("image", agent.Received.Blocks[1].Type);
+            Assert.Equal("AAAA", agent.Received.Blocks[1].Data);
+            Assert.Equal("image/png", agent.Received.Blocks[1].MimeType);
+            Assert.Equal("hi", agent.Received.Text);
+        }
+
+        [Fact]
+        public async Task NonTextPrompt_IsAccepted()
+        {
+            var (handler, agent) = Setup(new AgentCapabilities { ImagePrompts = true });
+
+            var resp = await handler.HandleRequestAsync(Prompt(
+                "[{\"type\":\"image\",\"data\":\"AAAA\",\"mimeType\":\"image/png\"}]"));
+
+            Assert.True(resp!.IsSuccess);
+            Assert.Single(agent.Received!.Blocks);
+            Assert.Equal(string.Empty, agent.Received.Text);
+        }
+
+        [Fact]
+        public async Task ImageWithoutCapability_ReturnsInvalidParams()
+        {
+            var (handler, agent) = Setup(new AgentCapabilities()); // image not supported
+
+            var resp = await handler.HandleRequestAsync(Prompt(
+                "[{\"type\":\"image\",\"data\":\"AAAA\",\"mimeType\":\"image/png\"}]"));
+
+            Assert.True(resp!.IsError);
+            Assert.Equal(JsonRpcErrorCodes.InvalidParams, resp.Error!.Code);
+            Assert.Null(agent.Received);
+        }
+
+        [Fact]
+        public async Task ResourceLink_AcceptedWithoutEmbeddedCapability()
+        {
+            var (handler, agent) = Setup(new AgentCapabilities()); // embeddedContext false
+
+            var resp = await handler.HandleRequestAsync(Prompt(
+                "[{\"type\":\"resource_link\",\"uri\":\"file:///x\",\"name\":\"x\"}]"));
+
+            Assert.True(resp!.IsSuccess);
+            Assert.Equal("resource_link", agent.Received!.Blocks[0].Type);
+            Assert.Equal("file:///x", agent.Received.Blocks[0].Uri);
+            Assert.Equal("x", agent.Received.Blocks[0].Name);
+        }
+
+        [Fact]
+        public async Task EmbeddedResource_PreservedWhenCapable()
+        {
+            var (handler, agent) = Setup(new AgentCapabilities { EmbeddedContext = true });
+
+            var resp = await handler.HandleRequestAsync(Prompt(
+                "[{\"type\":\"resource\",\"resource\":{\"uri\":\"file:///x\",\"text\":\"content\"}}]"));
+
+            Assert.True(resp!.IsSuccess);
+            Assert.NotNull(agent.Received!.Blocks[0].Resource);
+            Assert.Equal("content", agent.Received.Blocks[0].Resource!.Text);
+            Assert.Equal("file:///x", agent.Received.Blocks[0].Resource!.Uri);
+        }
+
+        private sealed class CapturingAgent : IAgentProvider
+        {
+            public PromptMessage? Received;
+            public AgentCapabilities Caps = new();
+
+            public Task<AgentResponse> ProcessPromptAsync(string sessionId, PromptMessage prompt, IResponseStreamer streamer, CancellationToken cancellationToken)
+            {
+                Received = prompt;
+                return Task.FromResult(new AgentResponse { StopReason = StopReason.Completed });
+            }
+
+            public Task<SessionMetadata> CreateSessionAsync(NewSessionParams? parameters, CancellationToken cancellationToken)
+                => Task.FromResult(new SessionMetadata { SessionId = "s1" });
+            public Task<SessionMetadata?> LoadSessionAsync(string sessionId, CancellationToken cancellationToken)
+                => Task.FromResult<SessionMetadata?>(null);
+            public Task CancelSessionAsync(string sessionId, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task<bool> SetSessionModeAsync(string sessionId, string mode, CancellationToken cancellationToken) => Task.FromResult(true);
+            public Task<bool> SetSessionModelAsync(string sessionId, string model, CancellationToken cancellationToken) => Task.FromResult(true);
+            public AgentCapabilities GetCapabilities() => Caps;
+        }
+    }
+}

--- a/tests/Andy.Acp.Tests/Protocol/SessionUpdateStreamerTests.cs
+++ b/tests/Andy.Acp.Tests/Protocol/SessionUpdateStreamerTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Agent;
+using Andy.Acp.Core.Protocol;
+using Andy.Acp.Core.Transport;
+using Xunit;
+
+namespace Andy.Acp.Tests.Protocol
+{
+    /// <summary>
+    /// Verifies that every IResponseStreamer operation emits a schema-valid ACP v1
+    /// session/update notification (issue #14). Tests assert the full serialized JSON.
+    /// </summary>
+    public class SessionUpdateStreamerTests
+    {
+        private static (SessionUpdateStreamer streamer, CapturingTransport transport) Create()
+        {
+            var transport = new CapturingTransport();
+            return (new SessionUpdateStreamer(transport, "sess-1"), transport);
+        }
+
+        private static JsonElement Update(CapturingTransport t)
+        {
+            var doc = JsonDocument.Parse(t.Messages[^1]);
+            var root = doc.RootElement;
+            Assert.Equal("2.0", root.GetProperty("jsonrpc").GetString());
+            Assert.Equal("session/update", root.GetProperty("method").GetString());
+            var p = root.GetProperty("params");
+            Assert.Equal("sess-1", p.GetProperty("sessionId").GetString());
+            return p.GetProperty("update").Clone();
+        }
+
+        [Fact]
+        public async Task MessageChunk_EmitsAgentMessageChunk()
+        {
+            var (s, t) = Create();
+            await s.SendMessageChunkAsync("hello", CancellationToken.None);
+
+            var u = Update(t);
+            Assert.Equal("agent_message_chunk", u.GetProperty("sessionUpdate").GetString());
+            Assert.Equal("text", u.GetProperty("content").GetProperty("type").GetString());
+            Assert.Equal("hello", u.GetProperty("content").GetProperty("text").GetString());
+            // No nonstandard top-level type/data members.
+            Assert.False(u.TryGetProperty("type", out _));
+            Assert.False(u.TryGetProperty("data", out _));
+        }
+
+        [Fact]
+        public async Task Thinking_EmitsAgentThoughtChunk()
+        {
+            var (s, t) = Create();
+            await s.SendThinkingAsync("pondering", CancellationToken.None);
+
+            var u = Update(t);
+            Assert.Equal("agent_thought_chunk", u.GetProperty("sessionUpdate").GetString());
+            Assert.Equal("pondering", u.GetProperty("content").GetProperty("text").GetString());
+        }
+
+        [Fact]
+        public async Task ToolCall_EmitsToolCallWithDefaults()
+        {
+            var (s, t) = Create();
+            await s.SendToolCallAsync(new ToolCall { Id = "t1", Name = "read_file", Input = new { path = "/x" } }, CancellationToken.None);
+
+            var u = Update(t);
+            Assert.Equal("tool_call", u.GetProperty("sessionUpdate").GetString());
+            Assert.Equal("t1", u.GetProperty("toolCallId").GetString());
+            Assert.Equal("read_file", u.GetProperty("title").GetString());
+            Assert.Equal("other", u.GetProperty("kind").GetString());
+            Assert.Equal("pending", u.GetProperty("status").GetString());
+            Assert.Equal("/x", u.GetProperty("rawInput").GetProperty("path").GetString());
+        }
+
+        [Fact]
+        public async Task ToolResult_Success_EmitsCompletedToolCallUpdate()
+        {
+            var (s, t) = Create();
+            await s.SendToolResultAsync(new ToolResult { CallId = "t1", Content = "done" }, CancellationToken.None);
+
+            var u = Update(t);
+            Assert.Equal("tool_call_update", u.GetProperty("sessionUpdate").GetString());
+            Assert.Equal("t1", u.GetProperty("toolCallId").GetString());
+            Assert.Equal("completed", u.GetProperty("status").GetString());
+            var content = u.GetProperty("content");
+            Assert.Equal("content", content[0].GetProperty("type").GetString());
+            Assert.Equal("done", content[0].GetProperty("content").GetProperty("text").GetString());
+        }
+
+        [Fact]
+        public async Task ToolResult_Error_EmitsFailedStatus()
+        {
+            var (s, t) = Create();
+            await s.SendToolResultAsync(new ToolResult { CallId = "t1", IsError = true, Content = "boom" }, CancellationToken.None);
+
+            var u = Update(t);
+            Assert.Equal("failed", u.GetProperty("status").GetString());
+        }
+
+        [Fact]
+        public async Task Plan_EmitsEntriesWithPriorityAndStatus()
+        {
+            var (s, t) = Create();
+            await s.SendExecutionPlanAsync(new ExecutionPlan
+            {
+                Entries = new List<PlanEntry>
+                {
+                    new() { Content = "step a", Priority = "high", Status = "in_progress" }
+                }
+            }, CancellationToken.None);
+
+            var u = Update(t);
+            Assert.Equal("plan", u.GetProperty("sessionUpdate").GetString());
+            var e = u.GetProperty("entries")[0];
+            Assert.Equal("step a", e.GetProperty("content").GetString());
+            Assert.Equal("high", e.GetProperty("priority").GetString());
+            Assert.Equal("in_progress", e.GetProperty("status").GetString());
+        }
+
+        [Fact]
+        public async Task Plan_FromSteps_DerivesValidEntries()
+        {
+            var (s, t) = Create();
+            await s.SendExecutionPlanAsync(new ExecutionPlan { Steps = new[] { "first", "second" } }, CancellationToken.None);
+
+            var u = Update(t);
+            var entries = u.GetProperty("entries");
+            Assert.Equal(2, entries.GetArrayLength());
+            Assert.Equal("first", entries[0].GetProperty("content").GetString());
+            Assert.Equal("medium", entries[0].GetProperty("priority").GetString());
+            Assert.Equal("pending", entries[0].GetProperty("status").GetString());
+        }
+
+        private sealed class CapturingTransport : ITransport
+        {
+            public List<string> Messages { get; } = new();
+            public bool IsConnected => true;
+            public Task<string> ReadMessageAsync(CancellationToken cancellationToken = default)
+                => Task.FromResult(string.Empty);
+            public Task WriteMessageAsync(string message, CancellationToken cancellationToken = default)
+            {
+                Messages.Add(message);
+                return Task.CompletedTask;
+            }
+            public Task CloseAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
Part of the ACP v1 wire-model epic (#11). Stacked on the foundation PR #22 (base branch = `fix/acp-foundation-transport-lifecycle`).

This lands the two most self-contained wire-model fixes with full tests. The remaining epic work (#12 lifecycle models, #13 bidirectional fs/terminal/permission, and session/load replay) is described below and will follow as separate PRs.

## #14 — schema-valid session/update notifications
`SessionUpdateStreamer` now wraps every update in the ACP v1 envelope `params.sessionId` + `params.update` with a `sessionUpdate` discriminator:
- message chunks → `agent_message_chunk`
- thinking → `agent_thought_chunk`
- tool calls → `tool_call` (`toolCallId`/`title`/`kind`/`status`/`rawInput`)
- tool results → `tool_call_update` (`completed`/`failed` + `content`)
- plans → `plan` with valid `entries` (`content`/`priority`/`status`)

The prior nonstandard top-level `type`/`data` envelopes are gone. Uses the shared `JsonRpcSerializer.Options`; write failures propagate (cancellation always; transport errors logged + rethrown) instead of being swallowed. +7 tests asserting full serialized JSON.

## #16 — preserve prompt content blocks + non-text prompts
`PromptMessage` now carries the full ordered list of ACP content blocks (text, image, audio, resource, resource_link) instead of only concatenated text. Non-text prompts are accepted (the "prompt text is required" rejection is removed). Blocks are validated against negotiated capabilities — text and resource_link are baseline-supported; image/audio/embedded-resource require the corresponding capability. +5 tests.

## Not yet in this PR (tracked for follow-ups)
- **#12** initialize/session lifecycle models (integer protocol-version negotiation, `ClientCapabilities`/`AgentCapabilities` shapes, `session/new` cwd+mcpServers, `modeId` for set_mode, drop `session/set_model`, remove `initialized`/`shutdown`, initialize-before-session ordering).
- **#13** bidirectional agent→client fs/terminal/permission requests.
- **#16 (remainder)** `session/load` history replay — coupled to the #12 load response model.

## Verification
All **269** unit tests pass (12 new here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)