### PR TITLE
feat: implement optional ACP v1 surface — auth, config options, session catalog, all update variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ andy-acp/
 │       ├── Server/                 # Unified ACP server
 │       └── Tools/                  # Tool framework (MCP compatibility)
 ├── tests/
-│   └── Andy.Acp.Tests/             # Comprehensive unit tests (276 tests)
+│   └── Andy.Acp.Tests/             # Comprehensive unit tests (303 tests)
 │       ├── Transport/
 │       ├── JsonRpc/
 │       ├── Session/
@@ -155,7 +155,7 @@ andy-acp/
 - **Response streaming** working (word-by-word display in Zed)
 - **Session management** properly tracking conversation state
 
-**Total: 276 tests passing** (including schema-backed ACP v1 validation and end-to-end stdio flows)
+**Total: 303 tests passing** (including schema-backed ACP v1 validation and end-to-end stdio flows)
 
 ## Supported ACP version and capabilities
 
@@ -167,9 +167,16 @@ andy-acp/
 - **Client capabilities consumed:** `fs.readTextFile`, `fs.writeTextFile`, and `terminal`.
   The agent issues `fs/*`, `terminal/*`, and `session/request_permission` **to the client**
   and only when the client advertised the matching capability.
-- **Lifecycle methods:** `initialize`, `session/new`, `session/load`, `session/prompt`,
-  `session/set_mode` (by `modeId`), and the `session/cancel` notification. `initialized`,
-  `shutdown`, and `session/set_model` are **not** part of ACP v1 and are not implemented.
+- **Lifecycle methods:** `initialize`, optional `authenticate`/`logout`, `session/new`,
+  `session/load`, `session/prompt`, `session/set_mode` (by `modeId`), optional
+  `session/set_config_option` and the session catalog (`session/list`, `delete`,
+  `resume`, `close`), the `session/cancel` notification, and `$/cancel_request`.
+  `initialized`, `shutdown`, and `session/set_model` are **not** part of ACP v1 and are
+  not implemented (model selection flows through config options).
+- **Optional provider interfaces:** an `IAgentProvider` implementation opts into the
+  optional surface by additionally implementing `IAuthenticationProvider`,
+  `ISessionConfigProvider`, and/or `ISessionCatalogProvider` — capabilities and method
+  registration follow automatically.
 
 See **Known limitations** below for optional ACP v1 features not yet implemented.
 
@@ -393,24 +400,37 @@ The integration is in the [andy-cli repository](https://github.com/rivoli-ai/and
 
 Implemented and covered by tests:
 - `initialize` handshake with integer protocol-version negotiation
+- `authenticate` / `logout` with advertised auth methods and `-32000` auth-required
+  gating (opt-in via `IAuthenticationProvider`)
 - `session/new`, `session/load` (with history replay), `session/prompt`,
   `session/set_mode` (by `modeId`), `session/cancel`
-- All `session/update` variants (message/thought chunks, `tool_call`,
-  `tool_call_update`, `plan`)
+- `session/set_config_option` and config options in session responses — the ACP
+  mechanism for model selection and reasoning levels (opt-in via
+  `ISessionConfigProvider`)
+- Session catalog: `session/list`, `session/delete`, `session/resume`,
+  `session/close`, with `sessionCapabilities` advertisement (opt-in via
+  `ISessionCatalogProvider`)
+- All `session/update` variants: message/thought chunks, `tool_call` (with
+  `locations` and content/diff/terminal `ToolCallContent`), `tool_call_update`
+  (with `rawOutput`), `plan`, `available_commands_update`, `current_mode_update`,
+  `config_option_update`, `session_info_update`, `usage_update`
 - Multimodal prompt content blocks (text, image, audio, resource, resource_link),
   validated against negotiated capabilities
 - Agent → client `fs/read_text_file`, `fs/write_text_file`, `terminal/*`, and
   `session/request_permission`
+- `$/cancel_request` protocol-level cancellation (responds `-32800`)
+- ACP-reserved error codes: `-32000` auth required, `-32002` resource not found,
+  `-32800` request cancelled
 - Schema-backed validation of wire output against the pinned ACP v1 schema
+  (`schema-v1.20.0`)
 
-Not yet implemented (optional ACP v1 surface):
-- `authenticate` / `logout` and auth methods
-- `session/set_config_option` and the config-option system (models, reasoning levels)
-- `session/list`, `session/delete`, `session/resume`, `session/close`
-- MCP server transports beyond passing configuration through to the agent
-- `available_commands_update`, `current_mode_update`, `usage_update`,
-  `session_info_update`, `config_option_update` session updates
-- Diff/terminal `ToolCallContent` variants and tool-call `locations`
+Remaining gaps:
+- MCP server configurations are passed through to the agent as data; this library
+  does not itself connect to MCP servers
+- `SessionConfigOption` select groups (`SessionConfigSelectGroup`) are not modeled
+  (flat option lists only)
+- The `additionalDirectories` session capability marker is not advertised (the
+  field is still passed through to the agent when clients send it)
 
 JSON-RPC batch requests are intentionally **not** supported and are rejected.
 

--- a/src/Andy.Acp.Core/Agent/AgentModels.cs
+++ b/src/Andy.Acp.Core/Agent/AgentModels.cs
@@ -402,6 +402,13 @@ namespace Andy.Acp.Core.Agent
         public SessionModeState? Modes { get; set; }
 
         /// <summary>
+        /// Optional ACP session config options (models, reasoning levels, toggles). When
+        /// set, they are returned in the session/new, session/load, and session/resume
+        /// responses.
+        /// </summary>
+        public List<SessionConfigOption>? ConfigOptions { get; set; }
+
+        /// <summary>
         /// Additional metadata
         /// </summary>
         public Dictionary<string, object>? Metadata { get; set; }

--- a/src/Andy.Acp.Core/Agent/IResponseStreamer.cs
+++ b/src/Andy.Acp.Core/Agent/IResponseStreamer.cs
@@ -54,6 +54,58 @@ namespace Andy.Acp.Core.Agent
         /// <param name="plan">The execution plan</param>
         /// <param name="cancellationToken">Cancellation token</param>
         Task SendExecutionPlanAsync(ExecutionPlan plan, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Send the current set of slash-commands available in the session
+        /// (ACP <c>available_commands_update</c>).
+        /// </summary>
+        Task SendAvailableCommandsAsync(IReadOnlyList<AvailableCommand> commands, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Notify the client that the session's current mode changed
+        /// (ACP <c>current_mode_update</c>).
+        /// </summary>
+        Task SendCurrentModeAsync(string modeId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Notify the client that the session's config options changed
+        /// (ACP <c>config_option_update</c>).
+        /// </summary>
+        Task SendConfigOptionsAsync(IReadOnlyList<SessionConfigOption> configOptions, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Send updated session info such as a generated title
+        /// (ACP <c>session_info_update</c>).
+        /// </summary>
+        Task SendSessionInfoAsync(string? title, System.DateTimeOffset? updatedAt, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Send context-window usage (ACP <c>usage_update</c>): <paramref name="used"/>
+        /// tokens consumed out of a window of <paramref name="size"/>.
+        /// </summary>
+        Task SendUsageAsync(long used, long size, UsageCost? cost, CancellationToken cancellationToken);
+    }
+
+    /// <summary>A slash-command the session currently offers (ACP <c>AvailableCommand</c>).</summary>
+    public class AvailableCommand
+    {
+        /// <summary>Command name (e.g. "web", without the leading slash).</summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>Human-readable description.</summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>Optional hint describing the free-form input the command accepts.</summary>
+        public string? InputHint { get; set; }
+    }
+
+    /// <summary>Monetary cost carried by a usage update (ACP <c>Cost</c>).</summary>
+    public class UsageCost
+    {
+        public double Amount { get; set; }
+
+        /// <summary>ISO 4217 currency code (e.g. "USD").</summary>
+        public string Currency { get; set; } = "USD";
     }
 
     /// <summary>
@@ -91,6 +143,60 @@ namespace Andy.Acp.Core.Agent
         /// Raw input parameters for the tool (ACP <c>rawInput</c>).
         /// </summary>
         public object? Input { get; set; }
+
+        /// <summary>
+        /// File locations this tool call affects (ACP <c>locations</c>), enabling
+        /// follow-along in the client.
+        /// </summary>
+        public List<ToolCallLocation>? Locations { get; set; }
+
+        /// <summary>
+        /// Structured content produced or previewed by the call (ACP <c>content</c>).
+        /// </summary>
+        public List<ToolCallContent>? ContentItems { get; set; }
+    }
+
+    /// <summary>A file location a tool call affects (ACP <c>ToolCallLocation</c>).</summary>
+    public class ToolCallLocation
+    {
+        /// <summary>Absolute file path.</summary>
+        public string Path { get; set; } = string.Empty;
+
+        /// <summary>Optional 1-based line number.</summary>
+        public int? Line { get; set; }
+    }
+
+    /// <summary>
+    /// Content attached to a tool call or tool result (ACP <c>ToolCallContent</c>).
+    /// <see cref="Type"/> selects the variant:
+    /// <list type="bullet">
+    /// <item><c>content</c>: <see cref="Text"/> (or a full <see cref="Content"/> block)</item>
+    /// <item><c>diff</c>: <see cref="Path"/>, <see cref="NewText"/>, optional <see cref="OldText"/></item>
+    /// <item><c>terminal</c>: <see cref="TerminalId"/></item>
+    /// </list>
+    /// </summary>
+    public class ToolCallContent
+    {
+        /// <summary>Variant discriminator: content, diff, or terminal.</summary>
+        public string Type { get; set; } = "content";
+
+        /// <summary>Text convenience for the content variant.</summary>
+        public string? Text { get; set; }
+
+        /// <summary>Full content block for the content variant (overrides <see cref="Text"/>).</summary>
+        public ContentBlock? Content { get; set; }
+
+        /// <summary>Absolute file path (diff variant).</summary>
+        public string? Path { get; set; }
+
+        /// <summary>Original file text (diff variant; null for a new file).</summary>
+        public string? OldText { get; set; }
+
+        /// <summary>Replacement file text (diff variant).</summary>
+        public string? NewText { get; set; }
+
+        /// <summary>Terminal id (terminal variant), from a client-created terminal.</summary>
+        public string? TerminalId { get; set; }
     }
 
     /// <summary>
@@ -112,6 +218,18 @@ namespace Andy.Acp.Core.Agent
         /// The tool's output or error message
         /// </summary>
         public string? Content { get; set; }
+
+        /// <summary>
+        /// Structured content for the update (ACP <c>content</c>). When set, takes
+        /// precedence over the plain <see cref="Content"/> text.
+        /// </summary>
+        public List<ToolCallContent>? ContentItems { get; set; }
+
+        /// <summary>Raw tool output (ACP <c>rawOutput</c>).</summary>
+        public object? RawOutput { get; set; }
+
+        /// <summary>Updated file locations for the call (ACP <c>locations</c>).</summary>
+        public List<ToolCallLocation>? Locations { get; set; }
     }
 
     /// <summary>

--- a/src/Andy.Acp.Core/Agent/OptionalProviders.cs
+++ b/src/Andy.Acp.Core/Agent/OptionalProviders.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Andy.Acp.Core.Agent
+{
+    /// <summary>
+    /// Optional interface an <see cref="IAgentProvider"/> implementation can additionally
+    /// implement to support ACP authentication (<c>authenticate</c> / <c>logout</c>).
+    /// When implemented, the advertised auth methods are returned from <c>initialize</c>,
+    /// and session methods are gated behind authentication when
+    /// <see cref="RequiresAuthentication"/> is true.
+    /// </summary>
+    public interface IAuthenticationProvider
+    {
+        /// <summary>The auth methods advertised in the initialize response.</summary>
+        IReadOnlyList<AuthMethod> GetAuthMethods();
+
+        /// <summary>
+        /// Whether session methods require a successful <c>authenticate</c> call first.
+        /// When false, the agent merely offers optional authentication.
+        /// </summary>
+        bool RequiresAuthentication { get; }
+
+        /// <summary>Whether the agent supports the <c>logout</c> method.</summary>
+        bool SupportsLogout { get; }
+
+        /// <summary>
+        /// Performs authentication with the selected method. Throw to reject
+        /// (surfaces as a JSON-RPC error).
+        /// </summary>
+        Task AuthenticateAsync(string methodId, CancellationToken cancellationToken);
+
+        /// <summary>Ends the authenticated state. Only called when <see cref="SupportsLogout"/>.</summary>
+        Task LogoutAsync(CancellationToken cancellationToken);
+    }
+
+    /// <summary>An auth method offered by the agent.</summary>
+    public class AuthMethod
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+    }
+
+    /// <summary>
+    /// Optional interface for ACP session config options
+    /// (<c>session/set_config_option</c>). Config options are the ACP mechanism for
+    /// model selection, reasoning levels, and other session settings; the current
+    /// option set is returned via <see cref="SessionMetadata.ConfigOptions"/> on
+    /// session/new, load, and resume.
+    /// </summary>
+    public interface ISessionConfigProvider
+    {
+        /// <summary>
+        /// Applies a config option change and returns the full updated option list
+        /// (required by the ACP response shape). Throw for unknown configId/value
+        /// (surfaces as invalid-params).
+        /// </summary>
+        Task<IReadOnlyList<SessionConfigOption>> SetConfigOptionAsync(
+            string sessionId,
+            string configId,
+            SessionConfigValue value,
+            CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// The requested new value for a config option: either a select value id or a boolean.
+    /// </summary>
+    public class SessionConfigValue
+    {
+        /// <summary>The selected value id (select options).</summary>
+        public string? ValueId { get; set; }
+
+        /// <summary>The boolean value (boolean options).</summary>
+        public bool? BoolValue { get; set; }
+    }
+
+    /// <summary>
+    /// An ACP <c>SessionConfigOption</c>. <see cref="Type"/> selects the variant:
+    /// <c>select</c> uses <see cref="CurrentValueId"/> + <see cref="Options"/>;
+    /// <c>boolean</c> uses <see cref="CurrentBoolValue"/>.
+    /// </summary>
+    public class SessionConfigOption
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = "select";
+
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+
+        /// <summary>Optional ACP category: mode, model, model_config, or thought_level.</summary>
+        [JsonPropertyName("category")]
+        public string? Category { get; set; }
+
+        /// <summary>Current value id (select variant).</summary>
+        [JsonIgnore]
+        public string? CurrentValueId { get; set; }
+
+        /// <summary>Current value (boolean variant).</summary>
+        [JsonIgnore]
+        public bool? CurrentBoolValue { get; set; }
+
+        /// <summary>
+        /// The wire <c>currentValue</c>: a string for select options, a boolean for
+        /// boolean options.
+        /// </summary>
+        [JsonPropertyName("currentValue")]
+        public object? CurrentValue
+        {
+            get => Type == "boolean" ? CurrentBoolValue ?? false : CurrentValueId;
+            set
+            {
+                switch (value)
+                {
+                    case bool b: CurrentBoolValue = b; break;
+                    case string s: CurrentValueId = s; break;
+                    case System.Text.Json.JsonElement el when el.ValueKind is System.Text.Json.JsonValueKind.True or System.Text.Json.JsonValueKind.False:
+                        CurrentBoolValue = el.GetBoolean(); break;
+                    case System.Text.Json.JsonElement el when el.ValueKind is System.Text.Json.JsonValueKind.String:
+                        CurrentValueId = el.GetString(); break;
+                }
+            }
+        }
+
+        /// <summary>Available options (select variant).</summary>
+        [JsonPropertyName("options")]
+        public List<SessionConfigSelectOption>? Options { get; set; }
+    }
+
+    /// <summary>A selectable value of a select config option.</summary>
+    public class SessionConfigSelectOption
+    {
+        [JsonPropertyName("value")]
+        public string Value { get; set; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+    }
+
+    /// <summary>
+    /// Optional interface for the ACP session catalog methods
+    /// (<c>session/list</c>, <c>session/delete</c>, <c>session/resume</c>,
+    /// <c>session/close</c>). Implementing it advertises all four capabilities.
+    /// </summary>
+    public interface ISessionCatalogProvider
+    {
+        /// <summary>Lists stored sessions, optionally filtered by cwd, with cursor paging.</summary>
+        Task<SessionListResult> ListSessionsAsync(string? cwd, string? cursor, CancellationToken cancellationToken);
+
+        /// <summary>Deletes a stored session. Return false when the session does not exist.</summary>
+        Task<bool> DeleteSessionAsync(string sessionId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Resumes a session without history replay (unlike session/load).
+        /// Return null when the session does not exist.
+        /// </summary>
+        Task<SessionMetadata?> ResumeSessionAsync(LoadSessionParams parameters, CancellationToken cancellationToken);
+
+        /// <summary>Closes an active session, releasing per-session resources.</summary>
+        Task CloseSessionAsync(string sessionId, CancellationToken cancellationToken);
+    }
+
+    /// <summary>Result of listing sessions.</summary>
+    public class SessionListResult
+    {
+        public List<SessionCatalogEntry> Sessions { get; set; } = new();
+
+        /// <summary>Opaque cursor for the next page, or null when exhausted.</summary>
+        public string? NextCursor { get; set; }
+    }
+
+    /// <summary>A stored session, as listed by <c>session/list</c> (ACP <c>SessionInfo</c>).</summary>
+    public class SessionCatalogEntry
+    {
+        public string SessionId { get; set; } = string.Empty;
+
+        public string Cwd { get; set; } = string.Empty;
+
+        public List<string>? AdditionalDirectories { get; set; }
+
+        public string? Title { get; set; }
+
+        public DateTimeOffset? UpdatedAt { get; set; }
+    }
+}

--- a/src/Andy.Acp.Core/JsonRpc/JsonRpcErrorCodes.cs
+++ b/src/Andy.Acp.Core/JsonRpc/JsonRpcErrorCodes.cs
@@ -32,52 +32,65 @@ namespace Andy.Acp.Core.JsonRpc
         /// </summary>
         public const int InternalError = -32603;
 
-        // Server error codes (-32000 to -32099 are reserved for implementation-defined server-errors)
+        // ACP-defined error codes (reserved meanings in the Agent Client Protocol)
 
         /// <summary>
-        /// ACP session not initialized
+        /// ACP: authentication is required before this method can be called.
         /// </summary>
-        public const int SessionNotInitialized = -32000;
+        public const int AuthRequired = -32000;
 
         /// <summary>
-        /// ACP session already initialized
+        /// ACP: the referenced resource was not found.
         /// </summary>
-        public const int SessionAlreadyInitialized = -32001;
+        public const int ResourceNotFound = -32002;
+
+        /// <summary>
+        /// ACP: the request was cancelled (e.g. via $/cancel_request).
+        /// </summary>
+        public const int RequestCancelled = -32800;
+
+        /// <summary>
+        /// Alias for <see cref="RequestCancelled"/> kept for source compatibility.
+        /// </summary>
+        public const int Cancelled = RequestCancelled;
+
+        // Implementation-defined server error codes. These deliberately avoid the
+        // ACP-reserved values above (-32000, -32002, -32800).
+
+        /// <summary>
+        /// Connection not initialized (initialize has not completed)
+        /// </summary>
+        public const int SessionNotInitialized = -32010;
+
+        /// <summary>
+        /// Connection already initialized
+        /// </summary>
+        public const int SessionAlreadyInitialized = -32011;
 
         /// <summary>
         /// Invalid ACP protocol version
         /// </summary>
-        public const int InvalidProtocolVersion = -32002;
+        public const int InvalidProtocolVersion = -32012;
 
         /// <summary>
         /// Tool not found or not available
         /// </summary>
-        public const int ToolNotFound = -32003;
+        public const int ToolNotFound = -32013;
 
         /// <summary>
         /// Tool execution failed
         /// </summary>
-        public const int ToolExecutionFailed = -32004;
-
-        /// <summary>
-        /// Resource not found or not accessible
-        /// </summary>
-        public const int ResourceNotFound = -32005;
+        public const int ToolExecutionFailed = -32014;
 
         /// <summary>
         /// Resource access denied
         /// </summary>
-        public const int ResourceAccessDenied = -32006;
+        public const int ResourceAccessDenied = -32016;
 
         /// <summary>
         /// Operation timeout
         /// </summary>
-        public const int Timeout = -32007;
-
-        /// <summary>
-        /// Operation cancelled
-        /// </summary>
-        public const int Cancelled = -32008;
+        public const int Timeout = -32017;
 
         /// <summary>
         /// Gets a human-readable message for the given error code
@@ -93,15 +106,16 @@ namespace Andy.Acp.Core.JsonRpc
                 MethodNotFound => "Method not found",
                 InvalidParams => "Invalid params",
                 InternalError => "Internal error",
+                AuthRequired => "Authentication required",
+                ResourceNotFound => "Resource not found",
+                RequestCancelled => "Request cancelled",
                 SessionNotInitialized => "Session not initialized",
                 SessionAlreadyInitialized => "Session already initialized",
                 InvalidProtocolVersion => "Invalid protocol version",
                 ToolNotFound => "Tool not found",
                 ToolExecutionFailed => "Tool execution failed",
-                ResourceNotFound => "Resource not found",
                 ResourceAccessDenied => "Resource access denied",
                 Timeout => "Operation timeout",
-                Cancelled => "Operation cancelled",
                 _ => "Unknown error"
             };
         }

--- a/src/Andy.Acp.Core/Protocol/AcpLifecycleModels.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpLifecycleModels.cs
@@ -31,7 +31,7 @@ namespace Andy.Acp.Core.Protocol
         public AcpAgentCapabilities? AgentCapabilities { get; set; }
 
         [JsonPropertyName("authMethods")]
-        public List<object> AuthMethods { get; set; } = new();
+        public List<AuthMethodDescription> AuthMethods { get; set; } = new();
 
         [JsonPropertyName("agentInfo")]
         public Implementation? AgentInfo { get; set; }
@@ -81,6 +81,62 @@ namespace Andy.Acp.Core.Protocol
 
         [JsonPropertyName("mcpCapabilities")]
         public AcpMcpCapabilities? McpCapabilities { get; set; }
+
+        [JsonPropertyName("sessionCapabilities")]
+        public AcpSessionCapabilities? SessionCapabilities { get; set; }
+
+        [JsonPropertyName("auth")]
+        public AcpAgentAuthCapabilities? Auth { get; set; }
+    }
+
+    /// <summary>
+    /// An empty-object capability marker: in ACP several capability fields signal support
+    /// by their presence as <c>{}</c> rather than by a boolean value.
+    /// </summary>
+    public sealed class CapabilityMarker
+    {
+    }
+
+    /// <summary>
+    /// ACP <c>SessionCapabilities</c>: presence of a marker means the corresponding
+    /// session catalog method is supported.
+    /// </summary>
+    public class AcpSessionCapabilities
+    {
+        [JsonPropertyName("list")]
+        public CapabilityMarker? List { get; set; }
+
+        [JsonPropertyName("delete")]
+        public CapabilityMarker? Delete { get; set; }
+
+        [JsonPropertyName("resume")]
+        public CapabilityMarker? Resume { get; set; }
+
+        [JsonPropertyName("close")]
+        public CapabilityMarker? Close { get; set; }
+
+        [JsonPropertyName("additionalDirectories")]
+        public CapabilityMarker? AdditionalDirectories { get; set; }
+    }
+
+    /// <summary>ACP <c>AgentAuthCapabilities</c> (logout marker).</summary>
+    public class AcpAgentAuthCapabilities
+    {
+        [JsonPropertyName("logout")]
+        public CapabilityMarker? Logout { get; set; }
+    }
+
+    /// <summary>An advertised ACP auth method (variant <c>agent</c>).</summary>
+    public class AuthMethodDescription
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
     }
 
     /// <summary>ACP <c>PromptCapabilities</c>. Text and resource_link are baseline (not gated).</summary>
@@ -116,6 +172,13 @@ namespace Andy.Acp.Core.Protocol
     {
         /// <summary>True once a successful <c>initialize</c> exchange has completed.</summary>
         public bool Initialized { get; set; }
+
+        /// <summary>
+        /// True once <c>authenticate</c> has succeeded. Defaults to true; the initialize
+        /// handler sets it to false when the agent's authentication provider requires
+        /// authentication, and the authenticate handler sets it back on success.
+        /// </summary>
+        public bool Authenticated { get; set; } = true;
 
         /// <summary>The negotiated protocol version.</summary>
         public int ProtocolVersion { get; set; }

--- a/src/Andy.Acp.Core/Protocol/AcpProtocolHandler.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpProtocolHandler.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Andy.Acp.Core.Agent;
 using Andy.Acp.Core.JsonRpc;
 
 namespace Andy.Acp.Core.Protocol
@@ -19,6 +22,7 @@ namespace Andy.Acp.Core.Protocol
         private readonly AcpConnectionState _state;
         private readonly ServerInfo _serverInfo;
         private readonly AcpAgentCapabilities _agentCapabilities;
+        private readonly IAuthenticationProvider? _authProvider;
         private readonly ILogger<AcpProtocolHandler>? _logger;
 
         /// <summary>The highest ACP protocol version this agent supports.</summary>
@@ -31,11 +35,13 @@ namespace Andy.Acp.Core.Protocol
             AcpConnectionState state,
             ServerInfo serverInfo,
             AcpAgentCapabilities agentCapabilities,
-            ILogger<AcpProtocolHandler>? logger = null)
+            ILogger<AcpProtocolHandler>? logger = null,
+            IAuthenticationProvider? authProvider = null)
         {
             _state = state ?? throw new ArgumentNullException(nameof(state));
             _serverInfo = serverInfo ?? throw new ArgumentNullException(nameof(serverInfo));
             _agentCapabilities = agentCapabilities ?? throw new ArgumentNullException(nameof(agentCapabilities));
+            _authProvider = authProvider;
             _logger = logger;
         }
 
@@ -70,6 +76,8 @@ namespace Andy.Acp.Core.Protocol
             _state.ClientCapabilities = initParams.ClientCapabilities ?? new AcpClientCapabilities();
             _state.ProtocolVersion = negotiated;
             _state.Initialized = true;
+            // Agents that don't require authentication are implicitly authenticated.
+            _state.Authenticated = _authProvider?.RequiresAuthentication != true;
 
             _logger?.LogInformation(
                 "Initialized: negotiated protocol version {Version} (client requested {Requested})",
@@ -84,7 +92,9 @@ namespace Andy.Acp.Core.Protocol
                     Version = _serverInfo.Version
                 },
                 AgentCapabilities = _agentCapabilities,
-                AuthMethods = new()
+                AuthMethods = _authProvider?.GetAuthMethods()
+                    .Select(m => new AuthMethodDescription { Id = m.Id, Name = m.Name, Description = m.Description })
+                    .ToList() ?? new()
             };
 
             return Task.FromResult<object?>(result);
@@ -109,7 +119,51 @@ namespace Andy.Acp.Core.Protocol
         }
 
         /// <summary>
-        /// Registers the ACP lifecycle methods. Only <c>initialize</c> is part of ACP v1.
+        /// Handles the ACP <c>authenticate</c> request. On success the connection is marked
+        /// authenticated and session methods become available.
+        /// </summary>
+        public async Task<object?> HandleAuthenticateAsync(object? parameters, CancellationToken cancellationToken = default)
+        {
+            if (_authProvider == null)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.MethodNotFound, "Authentication is not supported");
+
+            if (!_state.Initialized)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.SessionNotInitialized,
+                    "Connection is not initialized. Call initialize first.");
+
+            var req = DeserializeParams<AuthenticateParams>(parameters);
+            if (string.IsNullOrEmpty(req?.MethodId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "methodId is required");
+
+            if (_authProvider.GetAuthMethods().All(m => m.Id != req!.MethodId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                    $"Unknown auth method: {req!.MethodId}");
+
+            await _authProvider.AuthenticateAsync(req!.MethodId, cancellationToken).ConfigureAwait(false);
+            _state.Authenticated = true;
+
+            _logger?.LogInformation("Authenticated via method {MethodId}", req.MethodId);
+
+            // ACP AuthenticateResponse is an empty object.
+            return new { };
+        }
+
+        /// <summary>Handles the ACP <c>logout</c> request.</summary>
+        public async Task<object?> HandleLogoutAsync(object? parameters, CancellationToken cancellationToken = default)
+        {
+            if (_authProvider == null || !_authProvider.SupportsLogout)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.MethodNotFound, "Logout is not supported");
+
+            await _authProvider.LogoutAsync(cancellationToken).ConfigureAwait(false);
+            _state.Authenticated = !_authProvider.RequiresAuthentication;
+
+            _logger?.LogInformation("Logged out");
+            return new { };
+        }
+
+        /// <summary>
+        /// Registers the ACP lifecycle methods: <c>initialize</c>, plus
+        /// <c>authenticate</c>/<c>logout</c> when an authentication provider is present.
         /// </summary>
         public void RegisterMethods(JsonRpcHandler jsonRpcHandler)
         {
@@ -117,7 +171,22 @@ namespace Andy.Acp.Core.Protocol
                 throw new ArgumentNullException(nameof(jsonRpcHandler));
 
             jsonRpcHandler.RegisterMethod("initialize", HandleInitializeAsync);
-            _logger?.LogInformation("Registered ACP protocol method: initialize");
+
+            if (_authProvider != null)
+            {
+                jsonRpcHandler.RegisterMethod("authenticate", HandleAuthenticateAsync);
+                if (_authProvider.SupportsLogout)
+                    jsonRpcHandler.RegisterMethod("logout", HandleLogoutAsync);
+            }
+
+            _logger?.LogInformation("Registered ACP protocol methods: initialize{Auth}",
+                _authProvider != null ? ", authenticate" + (_authProvider.SupportsLogout ? ", logout" : "") : "");
+        }
+
+        private class AuthenticateParams
+        {
+            [JsonPropertyName("methodId")]
+            public string MethodId { get; set; } = string.Empty;
         }
 
         private static T? DeserializeParams<T>(object? parameters) where T : class

--- a/src/Andy.Acp.Core/Protocol/AcpSessionHandler.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpSessionHandler.cs
@@ -65,11 +65,27 @@ namespace Andy.Acp.Core.Protocol
             _jsonRpcHandler.RegisterMethod("session/set_mode", HandleSetModeAsync);
             _jsonRpcHandler.RegisterMethod("session/cancel", HandleCancelAsync);
 
-            _logger?.LogInformation(
-                "Registered ACP session methods: session/new, session/load, session/prompt, session/set_mode, session/cancel");
+            // Optional ACP surface, registered only when the agent implements the
+            // corresponding provider interface (capabilities are advertised to match).
+            if (_agentProvider is ISessionConfigProvider)
+                _jsonRpcHandler.RegisterMethod("session/set_config_option", HandleSetConfigOptionAsync);
+
+            if (_agentProvider is ISessionCatalogProvider)
+            {
+                _jsonRpcHandler.RegisterMethod("session/list", HandleListSessionsAsync);
+                _jsonRpcHandler.RegisterMethod("session/delete", HandleDeleteSessionAsync);
+                _jsonRpcHandler.RegisterMethod("session/resume", HandleResumeSessionAsync);
+                _jsonRpcHandler.RegisterMethod("session/close", HandleCloseSessionAsync);
+            }
+
+            _logger?.LogInformation("Registered ACP session methods (config: {Config}, catalog: {Catalog})",
+                _agentProvider is ISessionConfigProvider, _agentProvider is ISessionCatalogProvider);
         }
 
-        /// <summary>Throws if the connection has not completed the initialize handshake.</summary>
+        /// <summary>
+        /// Throws if the connection has not completed the initialize handshake, or if the
+        /// agent requires authentication that has not happened yet (ACP error -32000).
+        /// </summary>
         private void EnsureInitialized()
         {
             if (!_state.Initialized)
@@ -77,6 +93,13 @@ namespace Andy.Acp.Core.Protocol
                 throw new JsonRpcProtocolException(
                     JsonRpcErrorCodes.SessionNotInitialized,
                     "Connection is not initialized. Call initialize first.");
+            }
+
+            if (!_state.Authenticated)
+            {
+                throw new JsonRpcProtocolException(
+                    JsonRpcErrorCodes.AuthRequired,
+                    "Authentication required. Call authenticate first.");
             }
         }
 
@@ -105,7 +128,8 @@ namespace Andy.Acp.Core.Protocol
             return new
             {
                 sessionId = metadata.SessionId,
-                modes = metadata.Modes
+                modes = metadata.Modes,
+                configOptions = metadata.ConfigOptions
             };
         }
 
@@ -145,8 +169,147 @@ namespace Andy.Acp.Core.Protocol
             // ACP LoadSessionResponse: optional modes/configOptions, no sessionId.
             return new
             {
-                modes = metadata.Modes
+                modes = metadata.Modes,
+                configOptions = metadata.ConfigOptions
             };
+        }
+
+        private async Task<object?> HandleSetConfigOptionAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            EnsureInitialized();
+
+            var configProvider = (ISessionConfigProvider)_agentProvider;
+            var req = DeserializeParams<SetConfigOptionRequest>(parameters);
+
+            if (string.IsNullOrEmpty(req?.SessionId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "sessionId is required");
+            if (string.IsNullOrEmpty(req!.ConfigId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "configId is required");
+
+            // The value variant is discriminated by JSON kind: boolean for the "boolean"
+            // variant, string for the default "value_id" variant.
+            var value = new SessionConfigValue();
+            if (req.Value.ValueKind is JsonValueKind.True or JsonValueKind.False)
+                value.BoolValue = req.Value.GetBoolean();
+            else if (req.Value.ValueKind is JsonValueKind.String)
+                value.ValueId = req.Value.GetString();
+            else
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                    "value must be a string (value id) or a boolean");
+
+            IReadOnlyList<SessionConfigOption> options;
+            try
+            {
+                options = await configProvider.SetConfigOptionAsync(req.SessionId, req.ConfigId, value, cancellationToken);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, ex.Message);
+            }
+
+            _logger?.LogInformation("Set config option {ConfigId} for session {SessionId}", req.ConfigId, req.SessionId);
+
+            // ACP SetSessionConfigOptionResponse: the full updated option list (required).
+            return new { configOptions = options };
+        }
+
+        private async Task<object?> HandleListSessionsAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            EnsureInitialized();
+
+            var catalog = (ISessionCatalogProvider)_agentProvider;
+            var req = DeserializeParams<ListSessionsRequest>(parameters) ?? new ListSessionsRequest();
+
+            var result = await catalog.ListSessionsAsync(req.Cwd, req.Cursor, cancellationToken);
+
+            return new
+            {
+                sessions = result.Sessions.Select(s => new
+                {
+                    sessionId = s.SessionId,
+                    cwd = s.Cwd,
+                    additionalDirectories = s.AdditionalDirectories,
+                    title = s.Title,
+                    updatedAt = s.UpdatedAt?.ToString("o")
+                }).ToArray(),
+                nextCursor = result.NextCursor
+            };
+        }
+
+        private async Task<object?> HandleDeleteSessionAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            EnsureInitialized();
+
+            var catalog = (ISessionCatalogProvider)_agentProvider;
+            var req = DeserializeParams<SessionIdRequest>(parameters);
+
+            if (string.IsNullOrEmpty(req?.SessionId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "sessionId is required");
+
+            var deleted = await catalog.DeleteSessionAsync(req!.SessionId, cancellationToken);
+            if (!deleted)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.ResourceNotFound,
+                    $"Session not found: {req.SessionId}");
+
+            _logger?.LogInformation("Deleted session {SessionId}", req.SessionId);
+            return new { };
+        }
+
+        private async Task<object?> HandleResumeSessionAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            EnsureInitialized();
+
+            var catalog = (ISessionCatalogProvider)_agentProvider;
+            var req = DeserializeParams<LoadSessionRequest>(parameters);
+
+            if (string.IsNullOrEmpty(req?.SessionId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "sessionId is required");
+            if (string.IsNullOrEmpty(req!.Cwd))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "cwd is required");
+
+            var resumeParams = new LoadSessionParams
+            {
+                SessionId = req.SessionId,
+                Cwd = req.Cwd,
+                McpServers = req.McpServers ?? new List<McpServerConfig>(),
+                AdditionalDirectories = req.AdditionalDirectories
+            };
+
+            var metadata = await catalog.ResumeSessionAsync(resumeParams, cancellationToken);
+            if (metadata == null)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.ResourceNotFound,
+                    $"Session not found: {req.SessionId}");
+
+            _logger?.LogInformation("Resumed session {SessionId}", req.SessionId);
+
+            // ACP ResumeSessionResponse: optional modes/configOptions (no history replay).
+            return new
+            {
+                modes = metadata.Modes,
+                configOptions = metadata.ConfigOptions
+            };
+        }
+
+        private async Task<object?> HandleCloseSessionAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            EnsureInitialized();
+
+            var catalog = (ISessionCatalogProvider)_agentProvider;
+            var req = DeserializeParams<SessionIdRequest>(parameters);
+
+            if (string.IsNullOrEmpty(req?.SessionId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "sessionId is required");
+
+            // Closing a session also cancels any prompt still in flight for it.
+            if (_activePrompts.TryGetValue(req!.SessionId, out var promptCts))
+            {
+                try { promptCts.Cancel(); } catch (ObjectDisposedException) { }
+            }
+
+            await catalog.CloseSessionAsync(req.SessionId, cancellationToken);
+
+            _logger?.LogInformation("Closed session {SessionId}", req.SessionId);
+            return new { };
         }
 
         private async Task<object?> HandlePromptAsync(object? parameters, CancellationToken cancellationToken)
@@ -378,6 +541,36 @@ namespace Andy.Acp.Core.Protocol
         {
             [JsonPropertyName("sessionId")]
             public string SessionId { get; set; } = string.Empty;
+        }
+
+        private class SessionIdRequest
+        {
+            [JsonPropertyName("sessionId")]
+            public string SessionId { get; set; } = string.Empty;
+        }
+
+        private class SetConfigOptionRequest
+        {
+            [JsonPropertyName("sessionId")]
+            public string SessionId { get; set; } = string.Empty;
+
+            [JsonPropertyName("configId")]
+            public string ConfigId { get; set; } = string.Empty;
+
+            [JsonPropertyName("type")]
+            public string? Type { get; set; }
+
+            [JsonPropertyName("value")]
+            public JsonElement Value { get; set; }
+        }
+
+        private class ListSessionsRequest
+        {
+            [JsonPropertyName("cwd")]
+            public string? Cwd { get; set; }
+
+            [JsonPropertyName("cursor")]
+            public string? Cursor { get; set; }
         }
     }
 }

--- a/src/Andy.Acp.Core/Protocol/SessionUpdateStreamer.cs
+++ b/src/Andy.Acp.Core/Protocol/SessionUpdateStreamer.cs
@@ -77,25 +77,32 @@ namespace Andy.Acp.Core.Protocol
                 title = string.IsNullOrEmpty(toolCall.Title) ? toolCall.Name : toolCall.Title,
                 kind = string.IsNullOrEmpty(toolCall.Kind) ? "other" : toolCall.Kind,
                 status = string.IsNullOrEmpty(toolCall.Status) ? "pending" : toolCall.Status,
-                rawInput = toolCall.Input
+                rawInput = toolCall.Input,
+                locations = MapLocations(toolCall.Locations),
+                content = MapToolContent(toolCall.ContentItems)
             }, cancellationToken);
         }
 
         public Task SendToolResultAsync(ToolResult result, CancellationToken cancellationToken)
         {
-            object? content = result.Content == null
-                ? null
-                : new object[]
+            // Structured content takes precedence; otherwise wrap the plain text.
+            object? content = MapToolContent(result.ContentItems);
+            if (content == null && result.Content != null)
+            {
+                content = new object[]
                 {
                     new { type = "content", content = new { type = "text", text = result.Content } }
                 };
+            }
 
             return SendUpdateAsync(new
             {
                 sessionUpdate = "tool_call_update",
                 toolCallId = result.CallId,
                 status = result.IsError ? "failed" : "completed",
-                content
+                content,
+                rawOutput = result.RawOutput,
+                locations = MapLocations(result.Locations)
             }, cancellationToken);
         }
 
@@ -113,6 +120,99 @@ namespace Andy.Acp.Core.Protocol
                 sessionUpdate = "plan",
                 entries
             }, cancellationToken);
+        }
+
+        public Task SendAvailableCommandsAsync(System.Collections.Generic.IReadOnlyList<AvailableCommand> commands, CancellationToken cancellationToken)
+        {
+            return SendUpdateAsync(new
+            {
+                sessionUpdate = "available_commands_update",
+                availableCommands = commands.Select(c => new
+                {
+                    name = c.Name,
+                    description = c.Description,
+                    input = c.InputHint == null ? null : new { hint = c.InputHint }
+                }).ToArray()
+            }, cancellationToken);
+        }
+
+        public Task SendCurrentModeAsync(string modeId, CancellationToken cancellationToken)
+        {
+            return SendUpdateAsync(new
+            {
+                sessionUpdate = "current_mode_update",
+                currentModeId = modeId
+            }, cancellationToken);
+        }
+
+        public Task SendConfigOptionsAsync(System.Collections.Generic.IReadOnlyList<SessionConfigOption> configOptions, CancellationToken cancellationToken)
+        {
+            return SendUpdateAsync(new
+            {
+                sessionUpdate = "config_option_update",
+                configOptions
+            }, cancellationToken);
+        }
+
+        public Task SendSessionInfoAsync(string? title, DateTimeOffset? updatedAt, CancellationToken cancellationToken)
+        {
+            return SendUpdateAsync(new
+            {
+                sessionUpdate = "session_info_update",
+                title,
+                updatedAt = updatedAt?.ToString("o")
+            }, cancellationToken);
+        }
+
+        public Task SendUsageAsync(long used, long size, UsageCost? cost, CancellationToken cancellationToken)
+        {
+            return SendUpdateAsync(new
+            {
+                sessionUpdate = "usage_update",
+                used,
+                size,
+                cost = cost == null ? null : new { amount = cost.Amount, currency = cost.Currency }
+            }, cancellationToken);
+        }
+
+        /// <summary>Maps tool-call locations to the ACP wire shape.</summary>
+        private static object? MapLocations(System.Collections.Generic.List<ToolCallLocation>? locations)
+        {
+            if (locations == null || locations.Count == 0)
+                return null;
+
+            return locations.Select(l => new { path = l.Path, line = l.Line }).ToArray();
+        }
+
+        /// <summary>
+        /// Maps <see cref="ToolCallContent"/> items to the ACP <c>ToolCallContent</c>
+        /// wire variants (content, diff, terminal).
+        /// </summary>
+        private static object? MapToolContent(System.Collections.Generic.List<ToolCallContent>? items)
+        {
+            if (items == null || items.Count == 0)
+                return null;
+
+            return items.Select<ToolCallContent, object>(item => item.Type switch
+            {
+                "diff" => new
+                {
+                    type = "diff",
+                    path = item.Path ?? string.Empty,
+                    oldText = item.OldText,
+                    newText = item.NewText ?? string.Empty
+                },
+                "terminal" => new
+                {
+                    type = "terminal",
+                    terminalId = item.TerminalId ?? string.Empty
+                },
+                _ => new
+                {
+                    type = "content",
+                    content = (object?)item.Content ?? new { type = "text", text = item.Text ?? string.Empty }
+                }
+            }).ToArray();
         }
 
         /// <summary>

--- a/src/Andy.Acp.Core/Server/AcpServer.cs
+++ b/src/Andy.Acp.Core/Server/AcpServer.cs
@@ -25,6 +25,10 @@ namespace Andy.Acp.Core.Server
         private readonly ILoggerFactory? _loggerFactory;
         private readonly ILogger<AcpServer>? _logger;
 
+        // In-flight inbound requests by canonical id, so $/cancel_request can cancel the
+        // request it targets. Cancelled requests respond with -32800 (request cancelled).
+        private readonly ConcurrentDictionary<string, CancellationTokenSource> _inFlightRequests = new();
+
         /// <summary>
         /// Create a new ACP server for the given agent. Filesystem and terminal operations
         /// are performed as agent → client requests via <see cref="Client.IAcpClient"/>
@@ -88,8 +92,11 @@ namespace Andy.Acp.Core.Server
                 // Create session manager
                 var sessionManager = new SessionManager(_loggerFactory?.CreateLogger<SessionManager>());
 
-                // Get agent capabilities and advertise them in the ACP shape.
+                // Get agent capabilities and advertise them in the ACP shape. Optional
+                // surface (session catalog, auth) is advertised from the optional
+                // provider interfaces the agent implements.
                 var agentCapabilities = _agentProvider.GetCapabilities();
+                var authProvider = _agentProvider as IAuthenticationProvider;
                 var acpAgentCapabilities = new AcpAgentCapabilities
                 {
                     LoadSession = agentCapabilities.LoadSession,
@@ -99,19 +106,33 @@ namespace Andy.Acp.Core.Server
                         Audio = agentCapabilities.AudioPrompts,
                         EmbeddedContext = agentCapabilities.EmbeddedContext
                     },
-                    McpCapabilities = new AcpMcpCapabilities { Http = false, Sse = false }
+                    McpCapabilities = new AcpMcpCapabilities { Http = false, Sse = false },
+                    SessionCapabilities = _agentProvider is ISessionCatalogProvider
+                        ? new AcpSessionCapabilities
+                        {
+                            List = new CapabilityMarker(),
+                            Delete = new CapabilityMarker(),
+                            Resume = new CapabilityMarker(),
+                            Close = new CapabilityMarker()
+                        }
+                        : null,
+                    Auth = authProvider?.SupportsLogout == true
+                        ? new AcpAgentAuthCapabilities { Logout = new CapabilityMarker() }
+                        : null
                 };
 
                 // Shared connection state enforces initialize-before-session ordering and
                 // carries the negotiated client capabilities.
                 var connectionState = new AcpConnectionState();
 
-                // Register the initialize handshake handler.
+                // Register the initialize handshake handler (plus authenticate/logout when
+                // the agent implements IAuthenticationProvider).
                 var protocolHandler = new AcpProtocolHandler(
                     connectionState,
                     _serverInfo,
                     acpAgentCapabilities,
-                    _loggerFactory?.CreateLogger<AcpProtocolHandler>());
+                    _loggerFactory?.CreateLogger<AcpProtocolHandler>(),
+                    authProvider);
                 protocolHandler.RegisterMethods(jsonRpcHandler);
 
                 // Agent → client request channel (fs/*, terminal/*, session/request_permission).
@@ -250,7 +271,33 @@ namespace Andy.Acp.Core.Server
                     _logger?.LogDebug("Processing {Kind}: {Method} (ID: {Id})",
                         request.IsNotification ? "notification" : "request", request.Method, request.Id);
 
-                    response = await jsonRpcHandler.HandleRequestAsync(request, cancellationToken).ConfigureAwait(false);
+                    if (request.Method == "$/cancel_request")
+                    {
+                        // ACP protocol-level cancellation: cancel the in-flight request with
+                        // the given id. This is a notification; no response is sent.
+                        HandleCancelRequest(request);
+                        return;
+                    }
+
+                    if (!request.IsNotification)
+                    {
+                        // Track cancellable in-flight requests by canonical id.
+                        var key = CanonicalId(request.Id);
+                        using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                        _inFlightRequests[key] = requestCts;
+                        try
+                        {
+                            response = await jsonRpcHandler.HandleRequestAsync(request, requestCts.Token).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            _inFlightRequests.TryRemove(key, out _);
+                        }
+                    }
+                    else
+                    {
+                        response = await jsonRpcHandler.HandleRequestAsync(request, cancellationToken).ConfigureAwait(false);
+                    }
                 }
                 else if (jsonRpcMessage is JsonRpcResponse responseMessage)
                 {
@@ -288,5 +335,49 @@ namespace Andy.Acp.Core.Server
                 }
             }
         }
+
+        /// <summary>
+        /// Handles a <c>$/cancel_request</c> notification by cancelling the matching
+        /// in-flight request, if any. Unknown or already-completed ids are ignored.
+        /// </summary>
+        private void HandleCancelRequest(JsonRpcRequest request)
+        {
+            string? key = null;
+            if (request.Params is System.Text.Json.JsonElement el &&
+                el.ValueKind == System.Text.Json.JsonValueKind.Object &&
+                el.TryGetProperty("requestId", out var idEl))
+            {
+                key = idEl.GetRawText();
+            }
+
+            if (key == null)
+            {
+                _logger?.LogWarning("$/cancel_request without a requestId; ignoring");
+                return;
+            }
+
+            if (_inFlightRequests.TryGetValue(key, out var cts))
+            {
+                _logger?.LogInformation("Cancelling in-flight request {RequestId}", key);
+                try { cts.Cancel(); } catch (ObjectDisposedException) { }
+            }
+            else
+            {
+                _logger?.LogDebug("$/cancel_request for unknown/completed request {RequestId}", key);
+            }
+        }
+
+        /// <summary>
+        /// Canonicalizes a request id for in-flight tracking so that the id in a
+        /// $/cancel_request matches regardless of representation. Uses raw JSON text
+        /// (e.g. <c>5</c> vs <c>"5"</c> stay distinct, as JSON-RPC requires).
+        /// </summary>
+        private static string CanonicalId(object? id) => id switch
+        {
+            null => "null",
+            System.Text.Json.JsonElement el => el.GetRawText(),
+            string s => "\"" + s + "\"",
+            _ => Convert.ToString(id, System.Globalization.CultureInfo.InvariantCulture) ?? "null"
+        };
     }
 }

--- a/tests/Andy.Acp.Tests/JsonRpc/JsonRpcErrorCodesTests.cs
+++ b/tests/Andy.Acp.Tests/JsonRpc/JsonRpcErrorCodesTests.cs
@@ -19,7 +19,7 @@ namespace Andy.Acp.Tests.JsonRpc
         [InlineData(JsonRpcErrorCodes.ResourceNotFound, "Resource not found")]
         [InlineData(JsonRpcErrorCodes.ResourceAccessDenied, "Resource access denied")]
         [InlineData(JsonRpcErrorCodes.Timeout, "Operation timeout")]
-        [InlineData(JsonRpcErrorCodes.Cancelled, "Operation cancelled")]
+        [InlineData(JsonRpcErrorCodes.RequestCancelled, "Request cancelled")]
         public void GetMessage_WithKnownErrorCode_ReturnsCorrectMessage(int errorCode, string expectedMessage)
         {
             // Act
@@ -104,16 +104,20 @@ namespace Andy.Acp.Tests.JsonRpc
         [Fact]
         public void AcpErrorCodes_AreInCorrectRange()
         {
-            // Assert ACP-specific error codes are in the -32000 to -32099 range
-            Assert.InRange(JsonRpcErrorCodes.SessionNotInitialized, -32099, -32000);
-            Assert.InRange(JsonRpcErrorCodes.SessionAlreadyInitialized, -32099, -32000);
-            Assert.InRange(JsonRpcErrorCodes.InvalidProtocolVersion, -32099, -32000);
-            Assert.InRange(JsonRpcErrorCodes.ToolNotFound, -32099, -32000);
-            Assert.InRange(JsonRpcErrorCodes.ToolExecutionFailed, -32099, -32000);
-            Assert.InRange(JsonRpcErrorCodes.ResourceNotFound, -32099, -32000);
-            Assert.InRange(JsonRpcErrorCodes.ResourceAccessDenied, -32099, -32000);
-            Assert.InRange(JsonRpcErrorCodes.Timeout, -32099, -32000);
-            Assert.InRange(JsonRpcErrorCodes.Cancelled, -32099, -32000);
+            // Implementation-defined codes stay in the -32000..-32099 server-error range
+            // while avoiding the ACP-reserved values (-32000, -32002, -32800).
+            Assert.InRange(JsonRpcErrorCodes.SessionNotInitialized, -32099, -32001);
+            Assert.InRange(JsonRpcErrorCodes.SessionAlreadyInitialized, -32099, -32001);
+            Assert.InRange(JsonRpcErrorCodes.InvalidProtocolVersion, -32099, -32001);
+            Assert.InRange(JsonRpcErrorCodes.ToolNotFound, -32099, -32001);
+            Assert.InRange(JsonRpcErrorCodes.ToolExecutionFailed, -32099, -32001);
+            Assert.InRange(JsonRpcErrorCodes.ResourceAccessDenied, -32099, -32001);
+            Assert.InRange(JsonRpcErrorCodes.Timeout, -32099, -32001);
+
+            // ACP-reserved codes carry their protocol-assigned values.
+            Assert.Equal(-32000, JsonRpcErrorCodes.AuthRequired);
+            Assert.Equal(-32002, JsonRpcErrorCodes.ResourceNotFound);
+            Assert.Equal(-32800, JsonRpcErrorCodes.RequestCancelled);
         }
     }
 }

--- a/tests/Andy.Acp.Tests/Protocol/OptionalSurfaceTests.cs
+++ b/tests/Andy.Acp.Tests/Protocol/OptionalSurfaceTests.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Agent;
+using Andy.Acp.Core.JsonRpc;
+using Andy.Acp.Core.Protocol;
+using Xunit;
+
+namespace Andy.Acp.Tests.Protocol
+{
+    /// <summary>
+    /// Tests for the optional ACP v1 surface: authenticate/logout with auth gating,
+    /// session/set_config_option, and the session catalog
+    /// (session/list, delete, resume, close).
+    /// </summary>
+    public class OptionalSurfaceTests
+    {
+        private static JsonElement Params(object o) =>
+            JsonDocument.Parse(JsonSerializer.Serialize(o, JsonRpcSerializer.Options)).RootElement.Clone();
+
+        private static JsonRpcRequest Req(string method, object p, long id = 1) =>
+            new() { Method = method, Id = id, Params = Params(p) };
+
+        private static (JsonRpcHandler rpc, FullAgent agent, AcpConnectionState state) Setup()
+        {
+            var rpc = new JsonRpcHandler();
+            var agent = new FullAgent();
+            var state = new AcpConnectionState();
+            var protocolHandler = new AcpProtocolHandler(
+                state,
+                new ServerInfo { Name = "T", Version = "1.0" },
+                new AcpAgentCapabilities(),
+                authProvider: agent);
+            protocolHandler.RegisterMethods(rpc);
+            var sessionHandler = new AcpSessionHandler(agent, rpc, state);
+            sessionHandler.RegisterMethods();
+            return (rpc, agent, state);
+        }
+
+        private static async Task InitializeAsync(JsonRpcHandler rpc)
+        {
+            var resp = await rpc.HandleRequestAsync(Req("initialize", new { protocolVersion = 1 }, 99));
+            Assert.True(resp!.IsSuccess);
+        }
+
+        // ---- authenticate / logout -------------------------------------------------
+
+        [Fact]
+        public async Task SessionNew_BeforeAuthenticate_ReturnsAuthRequired()
+        {
+            var (rpc, _, _) = Setup();
+            await InitializeAsync(rpc);
+
+            var resp = await rpc.HandleRequestAsync(Req("session/new", new { cwd = "/tmp", mcpServers = Array.Empty<object>() }));
+
+            Assert.True(resp!.IsError);
+            Assert.Equal(JsonRpcErrorCodes.AuthRequired, resp.Error!.Code);
+        }
+
+        [Fact]
+        public async Task Authenticate_UnlocksSessionMethods()
+        {
+            var (rpc, agent, state) = Setup();
+            await InitializeAsync(rpc);
+
+            var auth = await rpc.HandleRequestAsync(Req("authenticate", new { methodId = "api-key" }));
+            Assert.True(auth!.IsSuccess);
+            Assert.True(state.Authenticated);
+            Assert.Equal("api-key", agent.AuthenticatedWith);
+
+            var resp = await rpc.HandleRequestAsync(Req("session/new", new { cwd = "/tmp", mcpServers = Array.Empty<object>() }, 2));
+            Assert.True(resp!.IsSuccess);
+        }
+
+        [Fact]
+        public async Task Authenticate_UnknownMethod_InvalidParams()
+        {
+            var (rpc, _, _) = Setup();
+            await InitializeAsync(rpc);
+
+            var resp = await rpc.HandleRequestAsync(Req("authenticate", new { methodId = "nope" }));
+
+            Assert.True(resp!.IsError);
+            Assert.Equal(JsonRpcErrorCodes.InvalidParams, resp.Error!.Code);
+        }
+
+        [Fact]
+        public async Task Logout_RestoresAuthRequirement()
+        {
+            var (rpc, _, state) = Setup();
+            await InitializeAsync(rpc);
+            await rpc.HandleRequestAsync(Req("authenticate", new { methodId = "api-key" }));
+
+            var logout = await rpc.HandleRequestAsync(Req("logout", new { }, 3));
+            Assert.True(logout!.IsSuccess);
+            Assert.False(state.Authenticated);
+
+            var resp = await rpc.HandleRequestAsync(Req("session/new", new { cwd = "/tmp", mcpServers = Array.Empty<object>() }, 4));
+            Assert.Equal(JsonRpcErrorCodes.AuthRequired, resp!.Error!.Code);
+        }
+
+        [Fact]
+        public async Task Initialize_AdvertisesAuthMethods()
+        {
+            var (rpc, _, _) = Setup();
+
+            var resp = await rpc.HandleRequestAsync(Req("initialize", new { protocolVersion = 1 }, 99));
+
+            var json = JsonRpcSerializer.Serialize(resp!);
+            var result = JsonDocument.Parse(json).RootElement.GetProperty("result");
+            var methods = result.GetProperty("authMethods");
+            Assert.Equal(1, methods.GetArrayLength());
+            Assert.Equal("api-key", methods[0].GetProperty("id").GetString());
+        }
+
+        // ---- session/set_config_option ---------------------------------------------
+
+        [Fact]
+        public async Task SetConfigOption_ValueId_RoundTrips()
+        {
+            var (rpc, agent, _) = await AuthedSetup();
+
+            var resp = await rpc.HandleRequestAsync(Req("session/set_config_option",
+                new { sessionId = "s1", configId = "model", value = "claude-fable-5" }, 5));
+
+            Assert.True(resp!.IsSuccess);
+            Assert.Equal("model", agent.LastConfigId);
+            Assert.Equal("claude-fable-5", agent.LastConfigValue!.ValueId);
+
+            var json = JsonRpcSerializer.Serialize(resp);
+            var options = JsonDocument.Parse(json).RootElement.GetProperty("result").GetProperty("configOptions");
+            Assert.Equal("claude-fable-5", options[0].GetProperty("currentValue").GetString());
+        }
+
+        [Fact]
+        public async Task SetConfigOption_Boolean_RoundTrips()
+        {
+            var (rpc, agent, _) = await AuthedSetup();
+
+            var resp = await rpc.HandleRequestAsync(Req("session/set_config_option",
+                new { sessionId = "s1", configId = "thinking", type = "boolean", value = true }, 5));
+
+            Assert.True(resp!.IsSuccess);
+            Assert.True(agent.LastConfigValue!.BoolValue);
+        }
+
+        [Fact]
+        public async Task SetConfigOption_StructuredValue_InvalidParams()
+        {
+            var (rpc, _, _) = await AuthedSetup();
+
+            var resp = await rpc.HandleRequestAsync(Req("session/set_config_option",
+                new { sessionId = "s1", configId = "model", value = new { nested = true } }, 5));
+
+            Assert.Equal(JsonRpcErrorCodes.InvalidParams, resp!.Error!.Code);
+        }
+
+        // ---- session catalog --------------------------------------------------------
+
+        [Fact]
+        public async Task ListSessions_ReturnsEntriesAndCursor()
+        {
+            var (rpc, _, _) = await AuthedSetup();
+
+            var resp = await rpc.HandleRequestAsync(Req("session/list", new { cwd = "/tmp" }, 6));
+
+            var json = JsonRpcSerializer.Serialize(resp!);
+            var result = JsonDocument.Parse(json).RootElement.GetProperty("result");
+            var sessions = result.GetProperty("sessions");
+            Assert.Equal(1, sessions.GetArrayLength());
+            Assert.Equal("stored-1", sessions[0].GetProperty("sessionId").GetString());
+            Assert.Equal("/tmp", sessions[0].GetProperty("cwd").GetString());
+            Assert.Equal("next", result.GetProperty("nextCursor").GetString());
+        }
+
+        [Fact]
+        public async Task DeleteSession_Unknown_ReturnsResourceNotFound()
+        {
+            var (rpc, _, _) = await AuthedSetup();
+
+            var resp = await rpc.HandleRequestAsync(Req("session/delete", new { sessionId = "missing" }, 7));
+
+            Assert.Equal(JsonRpcErrorCodes.ResourceNotFound, resp!.Error!.Code);
+        }
+
+        [Fact]
+        public async Task DeleteSession_Known_Succeeds()
+        {
+            var (rpc, agent, _) = await AuthedSetup();
+
+            var resp = await rpc.HandleRequestAsync(Req("session/delete", new { sessionId = "stored-1" }, 7));
+
+            Assert.True(resp!.IsSuccess);
+            Assert.Equal("stored-1", agent.Deleted);
+        }
+
+        [Fact]
+        public async Task ResumeSession_ReturnsModesWithoutReplay()
+        {
+            var (rpc, agent, _) = await AuthedSetup();
+
+            var resp = await rpc.HandleRequestAsync(Req("session/resume",
+                new { sessionId = "stored-1", cwd = "/tmp" }, 8));
+
+            Assert.True(resp!.IsSuccess);
+            Assert.Equal("stored-1", agent.Resumed);
+            var json = JsonRpcSerializer.Serialize(resp);
+            var result = JsonDocument.Parse(json).RootElement.GetProperty("result");
+            Assert.Equal("chat", result.GetProperty("modes").GetProperty("currentModeId").GetString());
+            Assert.False(result.TryGetProperty("sessionId", out _));
+        }
+
+        [Fact]
+        public async Task CloseSession_Succeeds()
+        {
+            var (rpc, agent, _) = await AuthedSetup();
+
+            var resp = await rpc.HandleRequestAsync(Req("session/close", new { sessionId = "stored-1" }, 9));
+
+            Assert.True(resp!.IsSuccess);
+            Assert.Equal("stored-1", agent.Closed);
+        }
+
+        [Fact]
+        public async Task CatalogMethods_NotRegistered_WhenAgentLacksInterface()
+        {
+            var rpc = new JsonRpcHandler();
+            var state = new AcpConnectionState { Initialized = true };
+            var plainAgent = new PlainAgent();
+            new AcpSessionHandler(plainAgent, rpc, state).RegisterMethods();
+
+            Assert.False(rpc.SupportsMethod("session/list"));
+            Assert.False(rpc.SupportsMethod("session/set_config_option"));
+
+            var resp = await rpc.HandleRequestAsync(Req("session/list", new { }, 1));
+            Assert.Equal(JsonRpcErrorCodes.MethodNotFound, resp!.Error!.Code);
+        }
+
+        private static async Task<(JsonRpcHandler rpc, FullAgent agent, AcpConnectionState state)> AuthedSetup()
+        {
+            var setup = Setup();
+            await InitializeAsync(setup.rpc);
+            await setup.rpc.HandleRequestAsync(Req("authenticate", new { methodId = "api-key" }, 98));
+            return setup;
+        }
+
+        /// <summary>Agent implementing every optional provider interface.</summary>
+        private sealed class FullAgent : IAgentProvider, IAuthenticationProvider, ISessionConfigProvider, ISessionCatalogProvider
+        {
+            public string? AuthenticatedWith;
+            public string? LastConfigId;
+            public SessionConfigValue? LastConfigValue;
+            public string? Deleted;
+            public string? Resumed;
+            public string? Closed;
+
+            // IAgentProvider
+            public Task<AgentResponse> ProcessPromptAsync(string sessionId, PromptMessage prompt, IResponseStreamer streamer, CancellationToken ct)
+                => Task.FromResult(new AgentResponse { StopReason = StopReason.Completed });
+            public Task<SessionMetadata> CreateSessionAsync(NewSessionParams? parameters, CancellationToken ct)
+                => Task.FromResult(new SessionMetadata { SessionId = "s1" });
+            public Task<SessionMetadata?> LoadSessionAsync(LoadSessionParams parameters, IResponseStreamer streamer, CancellationToken ct)
+                => Task.FromResult<SessionMetadata?>(null);
+            public Task CancelSessionAsync(string sessionId, CancellationToken ct) => Task.CompletedTask;
+            public Task<bool> SetSessionModeAsync(string sessionId, string modeId, CancellationToken ct) => Task.FromResult(true);
+            public AgentCapabilities GetCapabilities() => new() { LoadSession = true };
+
+            // IAuthenticationProvider
+            public IReadOnlyList<AuthMethod> GetAuthMethods()
+                => new List<AuthMethod> { new() { Id = "api-key", Name = "API key" } };
+            public bool RequiresAuthentication => true;
+            public bool SupportsLogout => true;
+            public Task AuthenticateAsync(string methodId, CancellationToken ct)
+            {
+                AuthenticatedWith = methodId;
+                return Task.CompletedTask;
+            }
+            public Task LogoutAsync(CancellationToken ct) => Task.CompletedTask;
+
+            // ISessionConfigProvider
+            public Task<IReadOnlyList<SessionConfigOption>> SetConfigOptionAsync(string sessionId, string configId, SessionConfigValue value, CancellationToken ct)
+            {
+                LastConfigId = configId;
+                LastConfigValue = value;
+                return Task.FromResult<IReadOnlyList<SessionConfigOption>>(new List<SessionConfigOption>
+                {
+                    new()
+                    {
+                        Type = "select",
+                        Id = "model",
+                        Name = "Model",
+                        Category = "model",
+                        CurrentValueId = value.ValueId ?? "claude-fable-5",
+                        Options = new List<SessionConfigSelectOption>
+                        {
+                            new() { Value = "claude-fable-5", Name = "Fable 5" }
+                        }
+                    }
+                });
+            }
+
+            // ISessionCatalogProvider
+            public Task<SessionListResult> ListSessionsAsync(string? cwd, string? cursor, CancellationToken ct)
+                => Task.FromResult(new SessionListResult
+                {
+                    Sessions = new List<SessionCatalogEntry>
+                    {
+                        new()
+                        {
+                            SessionId = "stored-1",
+                            Cwd = cwd ?? "/",
+                            Title = "First",
+                            UpdatedAt = new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero)
+                        }
+                    },
+                    NextCursor = "next"
+                });
+            public Task<bool> DeleteSessionAsync(string sessionId, CancellationToken ct)
+            {
+                if (sessionId != "stored-1")
+                    return Task.FromResult(false);
+                Deleted = sessionId;
+                return Task.FromResult(true);
+            }
+            public Task<SessionMetadata?> ResumeSessionAsync(LoadSessionParams parameters, CancellationToken ct)
+            {
+                Resumed = parameters.SessionId;
+                return Task.FromResult<SessionMetadata?>(new SessionMetadata
+                {
+                    SessionId = parameters.SessionId,
+                    Modes = new SessionModeState
+                    {
+                        CurrentModeId = "chat",
+                        AvailableModes = new List<SessionMode> { new() { Id = "chat", Name = "Chat" } }
+                    }
+                });
+            }
+            public Task CloseSessionAsync(string sessionId, CancellationToken ct)
+            {
+                Closed = sessionId;
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>Baseline agent with no optional interfaces.</summary>
+        private sealed class PlainAgent : IAgentProvider
+        {
+            public Task<AgentResponse> ProcessPromptAsync(string sessionId, PromptMessage prompt, IResponseStreamer streamer, CancellationToken ct)
+                => Task.FromResult(new AgentResponse { StopReason = StopReason.Completed });
+            public Task<SessionMetadata> CreateSessionAsync(NewSessionParams? parameters, CancellationToken ct)
+                => Task.FromResult(new SessionMetadata { SessionId = "s1" });
+            public Task<SessionMetadata?> LoadSessionAsync(LoadSessionParams parameters, IResponseStreamer streamer, CancellationToken ct)
+                => Task.FromResult<SessionMetadata?>(null);
+            public Task CancelSessionAsync(string sessionId, CancellationToken ct) => Task.CompletedTask;
+            public Task<bool> SetSessionModeAsync(string sessionId, string modeId, CancellationToken ct) => Task.FromResult(true);
+            public AgentCapabilities GetCapabilities() => new();
+        }
+    }
+}

--- a/tests/Andy.Acp.Tests/Schema/SchemaConformanceTests.cs
+++ b/tests/Andy.Acp.Tests/Schema/SchemaConformanceTests.cs
@@ -126,6 +126,178 @@ namespace Andy.Acp.Tests.Schema
             Assert.False(result.IsValid);
         }
 
+        // ---- optional surface -------------------------------------------------------
+
+        [Fact]
+        public void InitializeResponse_WithAuthAndSessionCapabilities_IsSchemaValid()
+        {
+            var result = new AcpInitializeResult
+            {
+                ProtocolVersion = 1,
+                AgentInfo = new Implementation { Name = "T", Version = "1.0" },
+                AgentCapabilities = new AcpAgentCapabilities
+                {
+                    LoadSession = true,
+                    SessionCapabilities = new AcpSessionCapabilities
+                    {
+                        List = new CapabilityMarker(),
+                        Delete = new CapabilityMarker(),
+                        Resume = new CapabilityMarker(),
+                        Close = new CapabilityMarker()
+                    },
+                    Auth = new AcpAgentAuthCapabilities { Logout = new CapabilityMarker() }
+                },
+                AuthMethods = new List<AuthMethodDescription>
+                {
+                    new() { Id = "api-key", Name = "API key", Description = "Use an API key" }
+                }
+            };
+
+            AcpSchema.AssertValid("InitializeResponse", JsonSerializer.Serialize(result, JsonRpcSerializer.Options));
+        }
+
+        [Fact]
+        public void SetSessionConfigOptionResponse_IsSchemaValid()
+        {
+            var options = new List<SessionConfigOption>
+            {
+                new()
+                {
+                    Type = "select",
+                    Id = "model",
+                    Name = "Model",
+                    Category = "model",
+                    CurrentValueId = "claude-fable-5",
+                    Options = new List<SessionConfigSelectOption>
+                    {
+                        new() { Value = "claude-fable-5", Name = "Fable 5" },
+                        new() { Value = "claude-opus-4-8", Name = "Opus 4.8" }
+                    }
+                },
+                new()
+                {
+                    Type = "boolean",
+                    Id = "thinking",
+                    Name = "Extended thinking",
+                    Category = "thought_level",
+                    CurrentBoolValue = true
+                }
+            };
+
+            var json = JsonSerializer.Serialize(new { configOptions = options }, JsonRpcSerializer.Options);
+            AcpSchema.AssertValid("SetSessionConfigOptionResponse", json);
+        }
+
+        [Fact]
+        public void ListSessionsResponse_IsSchemaValid()
+        {
+            AcpSchema.AssertValid("ListSessionsResponse",
+                "{\"sessions\":[{\"sessionId\":\"s1\",\"cwd\":\"/tmp\",\"title\":\"First\",\"updatedAt\":\"2026-07-01T00:00:00.0000000+00:00\"}],\"nextCursor\":\"n\"}");
+        }
+
+        [Fact]
+        public void ResumeSessionResponse_IsSchemaValid()
+        {
+            AcpSchema.AssertValid("ResumeSessionResponse",
+                "{\"modes\":{\"currentModeId\":\"chat\",\"availableModes\":[{\"id\":\"chat\",\"name\":\"Chat\"}]}}");
+        }
+
+        [Fact]
+        public async Task SessionUpdate_AvailableCommands_IsSchemaValid()
+        {
+            var t = new CapturingTransport();
+            var s = new SessionUpdateStreamer(t, "s1");
+            await s.SendAvailableCommandsAsync(new List<AvailableCommand>
+            {
+                new() { Name = "web", Description = "Search the web", InputHint = "query" },
+                new() { Name = "clear", Description = "Clear the conversation" }
+            }, CancellationToken.None);
+            AcpSchema.AssertValid("SessionNotification", ParamsOf(t.Messages[0]));
+        }
+
+        [Fact]
+        public async Task SessionUpdate_CurrentMode_IsSchemaValid()
+        {
+            var t = new CapturingTransport();
+            var s = new SessionUpdateStreamer(t, "s1");
+            await s.SendCurrentModeAsync("architect", CancellationToken.None);
+            AcpSchema.AssertValid("SessionNotification", ParamsOf(t.Messages[0]));
+        }
+
+        [Fact]
+        public async Task SessionUpdate_ConfigOptions_IsSchemaValid()
+        {
+            var t = new CapturingTransport();
+            var s = new SessionUpdateStreamer(t, "s1");
+            await s.SendConfigOptionsAsync(new List<SessionConfigOption>
+            {
+                new()
+                {
+                    Type = "select",
+                    Id = "model",
+                    Name = "Model",
+                    CurrentValueId = "m1",
+                    Options = new List<SessionConfigSelectOption> { new() { Value = "m1", Name = "M1" } }
+                }
+            }, CancellationToken.None);
+            AcpSchema.AssertValid("SessionNotification", ParamsOf(t.Messages[0]));
+        }
+
+        [Fact]
+        public async Task SessionUpdate_SessionInfo_IsSchemaValid()
+        {
+            var t = new CapturingTransport();
+            var s = new SessionUpdateStreamer(t, "s1");
+            await s.SendSessionInfoAsync("My session", new System.DateTimeOffset(2026, 7, 21, 0, 0, 0, System.TimeSpan.Zero), CancellationToken.None);
+            AcpSchema.AssertValid("SessionNotification", ParamsOf(t.Messages[0]));
+        }
+
+        [Fact]
+        public async Task SessionUpdate_Usage_IsSchemaValid()
+        {
+            var t = new CapturingTransport();
+            var s = new SessionUpdateStreamer(t, "s1");
+            await s.SendUsageAsync(1200, 200000, new UsageCost { Amount = 0.42, Currency = "USD" }, CancellationToken.None);
+            AcpSchema.AssertValid("SessionNotification", ParamsOf(t.Messages[0]));
+        }
+
+        [Fact]
+        public async Task SessionUpdate_ToolCallWithDiffTerminalAndLocations_IsSchemaValid()
+        {
+            var t = new CapturingTransport();
+            var s = new SessionUpdateStreamer(t, "s1");
+            await s.SendToolCallAsync(new ToolCall
+            {
+                Id = "tc1",
+                Name = "edit_file",
+                Kind = "edit",
+                Status = "in_progress",
+                Locations = new List<ToolCallLocation> { new() { Path = "/src/a.cs", Line = 12 } },
+                ContentItems = new List<ToolCallContent>
+                {
+                    new() { Type = "diff", Path = "/src/a.cs", OldText = "old", NewText = "new" },
+                    new() { Type = "terminal", TerminalId = "term-1" },
+                    new() { Type = "content", Text = "preview" }
+                }
+            }, CancellationToken.None);
+            AcpSchema.AssertValid("SessionNotification", ParamsOf(t.Messages[0]));
+        }
+
+        [Fact]
+        public async Task SessionUpdate_ToolCallUpdateWithRawOutput_IsSchemaValid()
+        {
+            var t = new CapturingTransport();
+            var s = new SessionUpdateStreamer(t, "s1");
+            await s.SendToolResultAsync(new ToolResult
+            {
+                CallId = "tc1",
+                Content = "done",
+                RawOutput = new { exitCode = 0 },
+                Locations = new List<ToolCallLocation> { new() { Path = "/src/a.cs" } }
+            }, CancellationToken.None);
+            AcpSchema.AssertValid("SessionNotification", ParamsOf(t.Messages[0]));
+        }
+
         private sealed class CapturingTransport : ITransport
         {
             public List<string> Messages { get; } = new();

--- a/tests/Andy.Acp.Tests/Server/CancelRequestTests.cs
+++ b/tests/Andy.Acp.Tests/Server/CancelRequestTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Agent;
+using Andy.Acp.Core.JsonRpc;
+using Andy.Acp.Core.Server;
+using Xunit;
+
+namespace Andy.Acp.Tests.Server
+{
+    /// <summary>
+    /// End-to-end tests for the ACP <c>$/cancel_request</c> protocol notification:
+    /// cancelling an in-flight request produces a -32800 (request cancelled) response.
+    /// </summary>
+    public class CancelRequestTests
+    {
+        [Fact]
+        public async Task CancelRequest_CancelsInFlightLoad_WithRequestCancelledError()
+        {
+            var harness = new InMemoryDuplex();
+            var agent = new BlockingLoadAgent();
+            var server = new AcpServer(agent);
+
+            using var serverCts = new CancellationTokenSource();
+            var serverTask = server.RunAsync(harness.ServerTransport, serverCts.Token);
+
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":1}}""");
+            await harness.ReadMessageAsync();
+
+            // Start a session/load that blocks until cancelled.
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":7,"method":"session/load","params":{"sessionId":"s1","cwd":"/tmp","mcpServers":[]}}""");
+            Assert.True(await agent.Started.Task.WaitAsync(TimeSpan.FromSeconds(5)), "load did not start");
+
+            // Cancel it at the protocol level.
+            await harness.SendAsync("""{"jsonrpc":"2.0","method":"$/cancel_request","params":{"requestId":7}}""");
+
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var doc = JsonDocument.Parse(await harness.ReadMessageAsync(timeout.Token));
+            Assert.Equal(7, doc.RootElement.GetProperty("id").GetInt64());
+            Assert.Equal(JsonRpcErrorCodes.RequestCancelled,
+                doc.RootElement.GetProperty("error").GetProperty("code").GetInt32());
+
+            serverCts.Cancel();
+            harness.Complete();
+            try { await serverTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
+        }
+
+        [Fact]
+        public async Task CancelRequest_UnknownId_IsHarmless()
+        {
+            var harness = new InMemoryDuplex();
+            var server = new AcpServer(new BlockingLoadAgent());
+
+            using var serverCts = new CancellationTokenSource();
+            var serverTask = server.RunAsync(harness.ServerTransport, serverCts.Token);
+
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":1}}""");
+            await harness.ReadMessageAsync();
+
+            // Cancel a request that does not exist; no response, and the connection stays usable.
+            await harness.SendAsync("""{"jsonrpc":"2.0","method":"$/cancel_request","params":{"requestId":999}}""");
+
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/tmp","mcpServers":[]}}""");
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var doc = JsonDocument.Parse(await harness.ReadMessageAsync(timeout.Token));
+            Assert.Equal(1, doc.RootElement.GetProperty("id").GetInt64());
+            Assert.True(doc.RootElement.TryGetProperty("result", out _));
+
+            serverCts.Cancel();
+            harness.Complete();
+            try { await serverTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
+        }
+
+        /// <summary>Agent whose session/load blocks until its token is cancelled.</summary>
+        private sealed class BlockingLoadAgent : IAgentProvider
+        {
+            public readonly TaskCompletionSource<bool> Started =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public async Task<SessionMetadata?> LoadSessionAsync(LoadSessionParams parameters, IResponseStreamer streamer, CancellationToken cancellationToken)
+            {
+                Started.TrySetResult(true);
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+                return null;
+            }
+
+            public Task<AgentResponse> ProcessPromptAsync(string sessionId, PromptMessage prompt, IResponseStreamer streamer, CancellationToken ct)
+                => Task.FromResult(new AgentResponse { StopReason = StopReason.Completed });
+            public Task<SessionMetadata> CreateSessionAsync(NewSessionParams? parameters, CancellationToken ct)
+                => Task.FromResult(new SessionMetadata { SessionId = "s1" });
+            public Task CancelSessionAsync(string sessionId, CancellationToken ct) => Task.CompletedTask;
+            public Task<bool> SetSessionModeAsync(string sessionId, string modeId, CancellationToken ct) => Task.FromResult(true);
+            public AgentCapabilities GetCapabilities() => new() { LoadSession = true };
+        }
+    }
+}


### PR DESCRIPTION
Implements the previously deferred optional ACP v1 surface, closing out the "Not yet implemented" list from the README. Stacked on PR #24 (base = `fix/acp-lifecycle-bidirectional`).

## Upstream protocol review
- The pinned v1 schema is **byte-identical** to the latest stable release (`schema-v1.20.0`); `meta.json` (method directions) is also unchanged — no migration needed.
- Upstream has a **v2 alpha** (`schema-v2.0.0-alpha.2`): auth becomes `auth/login`/`auth/logout`, `session/load`/`set_mode` are replaced by `session/resume` + config options, and `fs/*`/`terminal/*` leave the client method set. Not implemented (alpha), but it confirms config options + session catalog are the forward-compatible v1 investment.

## What's new
**Authentication** (opt-in `IAuthenticationProvider`): `authenticate`/`logout`, advertised `authMethods` + `auth.logout` capability, and ACP `-32000` auth-required gating of session methods.

**Config options** (opt-in `ISessionConfigProvider`): `session/set_config_option` (value_id + boolean variants) returning the full updated option list; `configOptions` in session/new, load, and resume responses. This is the ACP path for model selection and reasoning levels.

**Session catalog** (opt-in `ISessionCatalogProvider`): `session/list` (cwd filter, cursor paging), `session/delete` (`-32002` when missing), `session/resume` (no replay), `session/close` (cancels in-flight prompt); `sessionCapabilities` markers advertised. Methods register only when the agent implements the interface.

**Session updates**: `available_commands_update`, `current_mode_update`, `config_option_update`, `session_info_update`, `usage_update`; `tool_call` gains `locations` and content/diff/terminal `ToolCallContent`; `tool_call_update` gains `rawOutput`, `locations`, structured content.

**`$/cancel_request`**: protocol-level cancellation of any in-flight request by id, responding `-32800`.

**Error-code conformance**: ACP-reserved codes honored (`-32000` auth required, `-32002` resource not found, `-32800` request cancelled); implementation-defined codes moved to `-32010..-32017`.

## Design note
Optional surface is opt-in via additional interfaces on the `IAgentProvider` implementation — existing agents (SimpleEchoAgent, andy-cli) compile and behave unchanged; capabilities and method registration follow the interfaces automatically.

## Verification
- 27 new tests: optional-surface handler tests, schema validation of **every** new wire shape against the pinned schema, and `$/cancel_request` end-to-end.
- **303 tests pass**; full solution builds in Release on .NET 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)