### PR TITLE
feat: close remaining ACP v1 conformance gaps (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,15 +424,22 @@ Implemented and covered by tests:
 - Schema-backed validation of wire output against the pinned ACP v1 schema
   (`schema-v1.20.0`)
 
-Remaining gaps:
-- MCP server configurations are passed through to the agent as data; this library
-  does not itself connect to MCP servers
-- `SessionConfigOption` select groups (`SessionConfigSelectGroup`) are not modeled
-  (flat option lists only)
-- The `additionalDirectories` session capability marker is not advertised (the
-  field is still passed through to the agent when clients send it)
+Also implemented (gap-closure epic):
+- Grouped select config options (`SessionConfigSelectGroup`) alongside flat lists
+- `sessionCapabilities.additionalDirectories` marker, driven by
+  `AgentCapabilities.AdditionalDirectories`
+- Agent-declared MCP transport capabilities (`AgentCapabilities.McpHttp`/`McpSse`)
+  advertised as `mcpCapabilities`; incoming `mcpServers` entries are validated
+  against them (stdio always accepted)
 
-JSON-RPC batch requests are intentionally **not** supported and are rejected.
+By design (not gaps):
+- MCP server configurations are **passed through to the agent as data**; connecting
+  to MCP servers is the agent's responsibility, out of scope for this wire-protocol
+  library
+- JSON-RPC batch requests are intentionally **not** supported and are rejected
+
+The protocol version served is centralized in `AcpVersions` (currently v1 only);
+no other code hardcodes a protocol version.
 
 ## Contributing
 

--- a/src/Andy.Acp.Core/Agent/IAgentProvider.cs
+++ b/src/Andy.Acp.Core/Agent/IAgentProvider.cs
@@ -106,6 +106,27 @@ namespace Andy.Acp.Core.Agent
         public bool EmbeddedContext { get; set; } = false;
 
         /// <summary>
+        /// Whether the agent supports additional readable directories on session
+        /// requests. Advertised as the <c>sessionCapabilities.additionalDirectories</c>
+        /// marker.
+        /// </summary>
+        public bool AdditionalDirectories { get; set; } = false;
+
+        /// <summary>
+        /// Whether the agent accepts HTTP MCP server configurations. Advertised as
+        /// <c>mcpCapabilities.http</c>; http configs are rejected with invalid-params
+        /// when false.
+        /// </summary>
+        public bool McpHttp { get; set; } = false;
+
+        /// <summary>
+        /// Whether the agent accepts SSE MCP server configurations. Advertised as
+        /// <c>mcpCapabilities.sse</c>; sse configs are rejected with invalid-params
+        /// when false.
+        /// </summary>
+        public bool McpSse { get; set; } = false;
+
+        /// <summary>
         /// Custom capabilities (extensibility)
         /// </summary>
         public Dictionary<string, object>? Extensions { get; set; }

--- a/src/Andy.Acp.Core/Agent/OptionalProviders.cs
+++ b/src/Andy.Acp.Core/Agent/OptionalProviders.cs
@@ -131,9 +131,23 @@ namespace Andy.Acp.Core.Agent
             }
         }
 
-        /// <summary>Available options (select variant).</summary>
-        [JsonPropertyName("options")]
+        /// <summary>Available options as a flat list (select variant).</summary>
+        [JsonIgnore]
         public List<SessionConfigSelectOption>? Options { get; set; }
+
+        /// <summary>
+        /// Available options organized in groups (select variant). When set, takes
+        /// precedence over <see cref="Options"/> on the wire.
+        /// </summary>
+        [JsonIgnore]
+        public List<SessionConfigSelectGroup>? Groups { get; set; }
+
+        /// <summary>
+        /// The wire <c>options</c> member: ACP allows either a flat option array or a
+        /// group array.
+        /// </summary>
+        [JsonPropertyName("options")]
+        public object? OptionsWire => Groups is { Count: > 0 } ? Groups : Options;
     }
 
     /// <summary>A selectable value of a select config option.</summary>
@@ -147,6 +161,20 @@ namespace Andy.Acp.Core.Agent
 
         [JsonPropertyName("description")]
         public string? Description { get; set; }
+    }
+
+    /// <summary>A named group of selectable values (ACP <c>SessionConfigSelectGroup</c>).</summary>
+    public class SessionConfigSelectGroup
+    {
+        /// <summary>Group id (ACP <c>group</c>).</summary>
+        [JsonPropertyName("group")]
+        public string Group { get; set; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("options")]
+        public List<SessionConfigSelectOption> Options { get; set; } = new();
     }
 
     /// <summary>

--- a/src/Andy.Acp.Core/Protocol/AcpProtocolHandler.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpProtocolHandler.cs
@@ -25,11 +25,11 @@ namespace Andy.Acp.Core.Protocol
         private readonly IAuthenticationProvider? _authProvider;
         private readonly ILogger<AcpProtocolHandler>? _logger;
 
-        /// <summary>The highest ACP protocol version this agent supports.</summary>
-        public const int ProtocolVersion = 1;
+        /// <summary>The highest ACP protocol version this agent supports (see <see cref="AcpVersions"/>).</summary>
+        public const int ProtocolVersion = AcpVersions.Current;
 
-        /// <summary>The lowest ACP protocol version this agent supports.</summary>
-        public const int MinProtocolVersion = 1;
+        /// <summary>The lowest ACP protocol version this agent supports (see <see cref="AcpVersions"/>).</summary>
+        public const int MinProtocolVersion = AcpVersions.Minimum;
 
         public AcpProtocolHandler(
             AcpConnectionState state,

--- a/src/Andy.Acp.Core/Protocol/AcpSessionHandler.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpSessionHandler.cs
@@ -114,6 +114,8 @@ namespace Andy.Acp.Core.Protocol
             if (!Path.IsPathRooted(req!.Cwd))
                 throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "cwd must be an absolute path");
 
+            ValidateMcpServers(req.McpServers);
+
             var sessionParams = new NewSessionParams
             {
                 Cwd = req.Cwd,
@@ -147,6 +149,8 @@ namespace Andy.Acp.Core.Protocol
                 throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "sessionId is required");
             if (string.IsNullOrEmpty(req!.Cwd))
                 throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "cwd is required");
+
+            ValidateMcpServers(req.McpServers);
 
             var loadParams = new LoadSessionParams
             {
@@ -266,6 +270,8 @@ namespace Andy.Acp.Core.Protocol
                 throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "sessionId is required");
             if (string.IsNullOrEmpty(req!.Cwd))
                 throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "cwd is required");
+
+            ValidateMcpServers(req.McpServers);
 
             var resumeParams = new LoadSessionParams
             {
@@ -417,6 +423,45 @@ namespace Andy.Acp.Core.Protocol
 
             // session/cancel is a notification; no response is sent.
             return null;
+        }
+
+        /// <summary>
+        /// Validates MCP server configurations against the agent's declared MCP transport
+        /// capabilities: stdio is always accepted; http and sse require the corresponding
+        /// capability, otherwise the request fails with invalid-params. The configurations
+        /// themselves are passed through to the agent as data — connecting to MCP servers
+        /// is the agent's responsibility, not this library's.
+        /// </summary>
+        private void ValidateMcpServers(List<McpServerConfig>? servers)
+        {
+            if (servers == null || servers.Count == 0)
+                return;
+
+            var caps = _agentProvider.GetCapabilities();
+
+            foreach (var server in servers)
+            {
+                switch (server.Type)
+                {
+                    case null:
+                    case "":
+                    case "stdio":
+                        break; // stdio is the baseline transport
+                    case "http":
+                        if (!caps.McpHttp)
+                            throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                                $"HTTP MCP servers are not supported by this agent (server: {server.Name})");
+                        break;
+                    case "sse":
+                        if (!caps.McpSse)
+                            throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                                $"SSE MCP servers are not supported by this agent (server: {server.Name})");
+                        break;
+                    default:
+                        throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                            $"Unknown MCP server type: {server.Type}");
+                }
+            }
         }
 
         /// <summary>

--- a/src/Andy.Acp.Core/Protocol/AcpVersions.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpVersions.cs
@@ -1,0 +1,26 @@
+namespace Andy.Acp.Core.Protocol
+{
+    /// <summary>
+    /// The single source of truth for the ACP protocol versions this library knows about.
+    /// All version constants, negotiation logic, and documentation must reference these
+    /// values — no other code may hardcode a protocol version number.
+    /// </summary>
+    public static class AcpVersions
+    {
+        /// <summary>
+        /// Stable ACP v1 (pinned to schema-v1.20.0). This is the default and currently
+        /// the only version served.
+        /// </summary>
+        public const int V1 = 1;
+
+        /// <summary>
+        /// The highest protocol version this library currently serves.
+        /// </summary>
+        public const int Current = V1;
+
+        /// <summary>
+        /// The lowest protocol version this library currently serves.
+        /// </summary>
+        public const int Minimum = V1;
+    }
+}

--- a/src/Andy.Acp.Core/Server/AcpServer.cs
+++ b/src/Andy.Acp.Core/Server/AcpServer.cs
@@ -106,14 +106,19 @@ namespace Andy.Acp.Core.Server
                         Audio = agentCapabilities.AudioPrompts,
                         EmbeddedContext = agentCapabilities.EmbeddedContext
                     },
-                    McpCapabilities = new AcpMcpCapabilities { Http = false, Sse = false },
-                    SessionCapabilities = _agentProvider is ISessionCatalogProvider
+                    McpCapabilities = new AcpMcpCapabilities
+                    {
+                        Http = agentCapabilities.McpHttp,
+                        Sse = agentCapabilities.McpSse
+                    },
+                    SessionCapabilities = _agentProvider is ISessionCatalogProvider || agentCapabilities.AdditionalDirectories
                         ? new AcpSessionCapabilities
                         {
-                            List = new CapabilityMarker(),
-                            Delete = new CapabilityMarker(),
-                            Resume = new CapabilityMarker(),
-                            Close = new CapabilityMarker()
+                            List = _agentProvider is ISessionCatalogProvider ? new CapabilityMarker() : null,
+                            Delete = _agentProvider is ISessionCatalogProvider ? new CapabilityMarker() : null,
+                            Resume = _agentProvider is ISessionCatalogProvider ? new CapabilityMarker() : null,
+                            Close = _agentProvider is ISessionCatalogProvider ? new CapabilityMarker() : null,
+                            AdditionalDirectories = agentCapabilities.AdditionalDirectories ? new CapabilityMarker() : null
                         }
                         : null,
                     Auth = authProvider?.SupportsLogout == true

--- a/tests/Andy.Acp.Tests/Protocol/GapClosureTests.cs
+++ b/tests/Andy.Acp.Tests/Protocol/GapClosureTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Agent;
+using Andy.Acp.Core.JsonRpc;
+using Andy.Acp.Core.Protocol;
+using Andy.Acp.Tests.Schema;
+using Xunit;
+
+namespace Andy.Acp.Tests.Protocol
+{
+    /// <summary>
+    /// Tests for the v1 gap-closure epic (#26): grouped select config options,
+    /// additionalDirectories capability marker, and agent-declared MCP transport
+    /// capabilities with mcpServers validation.
+    /// </summary>
+    public class GapClosureTests
+    {
+        // ---- grouped select options -------------------------------------------------
+
+        [Fact]
+        public void GroupedSelectOptions_SerializeSchemaValid()
+        {
+            var option = new SessionConfigOption
+            {
+                Type = "select",
+                Id = "model",
+                Name = "Model",
+                Category = "model",
+                CurrentValueId = "claude-fable-5",
+                Groups = new List<SessionConfigSelectGroup>
+                {
+                    new()
+                    {
+                        Group = "anthropic",
+                        Name = "Anthropic",
+                        Options = new List<SessionConfigSelectOption>
+                        {
+                            new() { Value = "claude-fable-5", Name = "Fable 5" },
+                            new() { Value = "claude-opus-4-8", Name = "Opus 4.8" }
+                        }
+                    },
+                    new()
+                    {
+                        Group = "local",
+                        Name = "Local",
+                        Options = new List<SessionConfigSelectOption>
+                        {
+                            new() { Value = "llama", Name = "Llama" }
+                        }
+                    }
+                }
+            };
+
+            var json = JsonSerializer.Serialize(new { configOptions = new[] { option } }, JsonRpcSerializer.Options);
+            AcpSchema.AssertValid("SetSessionConfigOptionResponse", json);
+
+            // The wire options member must be the group array.
+            var options = JsonDocument.Parse(json).RootElement
+                .GetProperty("configOptions")[0].GetProperty("options");
+            Assert.Equal(2, options.GetArrayLength());
+            Assert.Equal("anthropic", options[0].GetProperty("group").GetString());
+            Assert.Equal(2, options[0].GetProperty("options").GetArrayLength());
+        }
+
+        [Fact]
+        public void FlatSelectOptions_StillSerializeFlat()
+        {
+            var option = new SessionConfigOption
+            {
+                Type = "select",
+                Id = "model",
+                Name = "Model",
+                CurrentValueId = "m1",
+                Options = new List<SessionConfigSelectOption> { new() { Value = "m1", Name = "M1" } }
+            };
+
+            var json = JsonSerializer.Serialize(new { configOptions = new[] { option } }, JsonRpcSerializer.Options);
+            AcpSchema.AssertValid("SetSessionConfigOptionResponse", json);
+
+            var options = JsonDocument.Parse(json).RootElement
+                .GetProperty("configOptions")[0].GetProperty("options");
+            Assert.Equal("m1", options[0].GetProperty("value").GetString());
+        }
+
+        // ---- capability advertisement ----------------------------------------------
+
+        [Fact]
+        public void InitializeResponse_WithAdditionalDirectoriesAndMcpCaps_IsSchemaValid()
+        {
+            var result = new AcpInitializeResult
+            {
+                ProtocolVersion = AcpVersions.V1,
+                AgentInfo = new Implementation { Name = "T", Version = "1.0" },
+                AgentCapabilities = new AcpAgentCapabilities
+                {
+                    McpCapabilities = new AcpMcpCapabilities { Http = true, Sse = true },
+                    SessionCapabilities = new AcpSessionCapabilities
+                    {
+                        AdditionalDirectories = new CapabilityMarker()
+                    }
+                }
+            };
+
+            var json = JsonSerializer.Serialize(result, JsonRpcSerializer.Options);
+            AcpSchema.AssertValid("InitializeResponse", json);
+
+            var caps = JsonDocument.Parse(json).RootElement.GetProperty("agentCapabilities");
+            Assert.True(caps.GetProperty("mcpCapabilities").GetProperty("http").GetBoolean());
+            Assert.True(caps.GetProperty("sessionCapabilities").TryGetProperty("additionalDirectories", out _));
+            // Markers not set must be absent, not null.
+            Assert.False(caps.GetProperty("sessionCapabilities").TryGetProperty("list", out _));
+        }
+
+        // ---- MCP server validation --------------------------------------------------
+
+        private static (JsonRpcHandler rpc, McpAgent agent) Setup(bool http, bool sse)
+        {
+            var rpc = new JsonRpcHandler();
+            var agent = new McpAgent { Http = http, Sse = sse };
+            var state = new AcpConnectionState { Initialized = true };
+            new AcpSessionHandler(agent, rpc, state).RegisterMethods();
+            return (rpc, agent);
+        }
+
+        private static JsonRpcRequest NewSession(string mcpServersJson) => new()
+        {
+            Method = "session/new",
+            Id = 1,
+            Params = JsonDocument.Parse(
+                "{\"cwd\":\"/tmp\",\"mcpServers\":" + mcpServersJson + "}").RootElement.Clone()
+        };
+
+        [Fact]
+        public async Task HttpMcpServer_WithoutCapability_IsRejected()
+        {
+            var (rpc, agent) = Setup(http: false, sse: false);
+
+            var resp = await rpc.HandleRequestAsync(NewSession(
+                """[{"type":"http","name":"srv","url":"https://x","headers":[]}]"""));
+
+            Assert.True(resp!.IsError);
+            Assert.Equal(JsonRpcErrorCodes.InvalidParams, resp.Error!.Code);
+            Assert.Null(agent.LastNew);
+        }
+
+        [Fact]
+        public async Task HttpMcpServer_WithCapability_IsAccepted()
+        {
+            var (rpc, agent) = Setup(http: true, sse: false);
+
+            var resp = await rpc.HandleRequestAsync(NewSession(
+                """[{"type":"http","name":"srv","url":"https://x","headers":[]}]"""));
+
+            Assert.True(resp!.IsSuccess);
+            Assert.Equal("http", agent.LastNew!.McpServers[0].Type);
+            Assert.Equal("https://x", agent.LastNew.McpServers[0].Url);
+        }
+
+        [Fact]
+        public async Task SseMcpServer_WithoutCapability_IsRejected()
+        {
+            var (rpc, _) = Setup(http: true, sse: false);
+
+            var resp = await rpc.HandleRequestAsync(NewSession(
+                """[{"type":"sse","name":"srv","url":"https://x","headers":[]}]"""));
+
+            Assert.Equal(JsonRpcErrorCodes.InvalidParams, resp!.Error!.Code);
+        }
+
+        [Fact]
+        public async Task StdioMcpServer_AlwaysAccepted()
+        {
+            var (rpc, agent) = Setup(http: false, sse: false);
+
+            var resp = await rpc.HandleRequestAsync(NewSession(
+                """[{"name":"srv","command":"/bin/tool","args":[],"env":[]}]"""));
+
+            Assert.True(resp!.IsSuccess);
+            Assert.Equal("/bin/tool", agent.LastNew!.McpServers[0].Command);
+        }
+
+        private sealed class McpAgent : IAgentProvider
+        {
+            public bool Http;
+            public bool Sse;
+            public NewSessionParams? LastNew;
+
+            public Task<SessionMetadata> CreateSessionAsync(NewSessionParams? parameters, CancellationToken ct)
+            {
+                LastNew = parameters;
+                return Task.FromResult(new SessionMetadata { SessionId = "s1" });
+            }
+
+            public Task<AgentResponse> ProcessPromptAsync(string sessionId, PromptMessage prompt, IResponseStreamer streamer, CancellationToken ct)
+                => Task.FromResult(new AgentResponse { StopReason = StopReason.Completed });
+            public Task<SessionMetadata?> LoadSessionAsync(LoadSessionParams parameters, IResponseStreamer streamer, CancellationToken ct)
+                => Task.FromResult<SessionMetadata?>(null);
+            public Task CancelSessionAsync(string sessionId, CancellationToken ct) => Task.CompletedTask;
+            public Task<bool> SetSessionModeAsync(string sessionId, string modeId, CancellationToken ct) => Task.FromResult(true);
+            public AgentCapabilities GetCapabilities() => new() { McpHttp = Http, McpSse = Sse };
+        }
+    }
+}


### PR DESCRIPTION
Closes #26. Stacked on PR #25 (base = `feat/acp-optional-surface`).

Closes the final documented v1 gaps, completing the stable ACP v1 surface:

- **Grouped select config options** — `SessionConfigSelectGroup` modeled; the wire `options` member emits either a flat option array or a group array, both schema-valid.
- **`additionalDirectories` marker** — driven by a new `AgentCapabilities.AdditionalDirectories`; advertised in `sessionCapabilities` only when declared (absent markers stay absent, not null).
- **Agent-declared MCP transport capabilities** — `AgentCapabilities.McpHttp`/`McpSse` replace the hardcoded `mcpCapabilities` false/false; `session/new`, `load`, and `resume` now validate incoming `mcpServers` (http/sse rejected with invalid-params unless advertised; stdio always accepted). MCP configs remain pass-through data — connecting is the agent's responsibility, documented as by-design.
- **`AcpVersions`** — single source of truth for the served protocol version, referenced by negotiation; groundwork for the v2 epic (#30) so version support is never implied in more than one place.

+7 tests (grouped-option schema validation, marker advertisement, MCP validation matrix). **310 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)