### PR TITLE
feat: support ACP v2 (alpha) with explicit version selection (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,8 +438,46 @@ By design (not gaps):
   library
 - JSON-RPC batch requests are intentionally **not** supported and are rejected
 
-The protocol version served is centralized in `AcpVersions` (currently v1 only);
-no other code hardcodes a protocol version.
+## Choosing a protocol version
+
+The library serves **stable ACP v1 by default**. ACP v2 (**alpha**) support exists but
+must be explicitly opted into — v2 is alpha upstream and may change incompatibly:
+
+```csharp
+// Default: stable v1 only. A client requesting v2 is negotiated down to v1.
+var server = new AcpServer(agent);
+
+// Opt-in: serve v1 AND v2 alpha. Each connection's version is fixed at initialize.
+var server = new AcpServer(agent, options: new AcpServerOptions { EnableV2Alpha = true });
+```
+
+There is exactly one source of truth per concern, so the supported version is never
+ambiguous in code:
+
+| concern | single source of truth |
+|---|---|
+| Version constants | `AcpVersions` (`V1`, `V2Alpha`, `Default`, `All`) |
+| What this server serves | `AcpServerOptions.SupportedVersions` |
+| What this connection speaks | `AcpConnectionState.ProtocolVersion` (set at initialize) |
+| Which methods exist in which version | `AcpMethodRegistry` (derived from the vendored `meta.json` files) |
+
+Dispatch is centrally gated on the registry: calling a v1-only method (e.g.
+`session/load`) on a v2 connection — or a v2-only method (e.g. `auth/login`) on a v1
+connection — returns method-not-found regardless of what is registered. v2 wire models
+live in the separate `Andy.Acp.Core.Protocol.V2` namespace and are never mixed with v1
+types where the schemas differ.
+
+Key v2 differences handled automatically (the provider API stays version-neutral):
+`session/load` → `session/resume` + `replayFrom:{"type":"start"}`; `session/set_mode`
+→ config options; `authenticate`/`logout` → `auth/login`/`auth/logout`; prompt
+`stopReason` moves from the response to `state_update {state:"idle"}`; capability
+booleans become `{}` markers; config options use `configId`/`groupId`. On v2 there are
+no client-served `fs/*`/`terminal/*` methods, and `SendCurrentModeAsync` throws
+(v2 removed `current_mode_update` — use config options with category `mode`).
+
+Both pinned schemas are vendored in the test project (v1 = `schema-v1.20.0`,
+v2 = `schema-v2.0.0-alpha.x`), and CI validates all emitted wire shapes against the
+schema of the negotiated version.
 
 ## Contributing
 

--- a/src/Andy.Acp.Core/Client/AcpClient.cs
+++ b/src/Andy.Acp.Core/Client/AcpClient.cs
@@ -54,15 +54,28 @@ namespace Andy.Acp.Core.Client
             IReadOnlyList<PermissionOption> options,
             CancellationToken cancellationToken = default)
         {
-            var result = await SendRequestAsync<PermissionResponseDto>("session/request_permission", new
-            {
-                sessionId,
-                toolCall,
-                options
-            }, cancellationToken).ConfigureAwait(false);
+            // The wire shape differs by negotiated protocol version: v1 uses a flattened
+            // required toolCall; v2 requires a title and nests the tool call in a subject.
+            object requestParams = _state.ProtocolVersion == Protocol.AcpVersions.V2Alpha
+                ? new
+                {
+                    sessionId,
+                    title = string.IsNullOrEmpty(toolCall.Title) ? "Permission required" : toolCall.Title!,
+                    subject = new { type = "tool_call", toolCall },
+                    options
+                }
+                : new
+                {
+                    sessionId,
+                    toolCall,
+                    options
+                };
+
+            var result = await SendRequestAsync<PermissionResponseDto>(
+                "session/request_permission", requestParams, cancellationToken).ConfigureAwait(false);
 
             var outcome = result?.Outcome;
-            if (outcome == null || string.Equals(outcome.Outcome, "cancelled", StringComparison.Ordinal))
+            if (outcome == null || !string.Equals(outcome.Outcome, "selected", StringComparison.Ordinal))
                 return PermissionOutcome.CancelledOutcome();
 
             return PermissionOutcome.Selected(outcome.OptionId ?? string.Empty);

--- a/src/Andy.Acp.Core/Protocol/AcpMethodRegistry.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpMethodRegistry.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+
+namespace Andy.Acp.Core.Protocol
+{
+    /// <summary>
+    /// The per-method protocol-version map: which agent-side methods exist in which ACP
+    /// version. Derived from the vendored upstream method metadata
+    /// (<c>schema/v1/meta.json</c> and <c>schema/v2/meta.json</c>); this table is the only
+    /// place that knowledge lives. Dispatch consults it so a method that does not exist in
+    /// the connection's negotiated version returns method-not-found even when a handler is
+    /// registered.
+    /// </summary>
+    public static class AcpMethodRegistry
+    {
+        private static readonly Dictionary<string, int[]> Methods = new(StringComparer.Ordinal)
+        {
+            // Lifecycle
+            ["initialize"] = new[] { AcpVersions.V1, AcpVersions.V2Alpha },
+            ["authenticate"] = new[] { AcpVersions.V1 },          // v2: auth/login
+            ["logout"] = new[] { AcpVersions.V1 },                // v2: auth/logout
+            ["auth/login"] = new[] { AcpVersions.V2Alpha },
+            ["auth/logout"] = new[] { AcpVersions.V2Alpha },
+
+            // Sessions
+            ["session/new"] = new[] { AcpVersions.V1, AcpVersions.V2Alpha },
+            ["session/load"] = new[] { AcpVersions.V1 },          // v2: session/resume + replayFrom
+            ["session/set_mode"] = new[] { AcpVersions.V1 },      // v2: config option category "mode"
+            ["session/set_config_option"] = new[] { AcpVersions.V1, AcpVersions.V2Alpha },
+            ["session/prompt"] = new[] { AcpVersions.V1, AcpVersions.V2Alpha },
+            ["session/cancel"] = new[] { AcpVersions.V1, AcpVersions.V2Alpha },
+            ["session/list"] = new[] { AcpVersions.V1, AcpVersions.V2Alpha },
+            ["session/delete"] = new[] { AcpVersions.V1, AcpVersions.V2Alpha },
+            ["session/resume"] = new[] { AcpVersions.V1, AcpVersions.V2Alpha },
+            ["session/close"] = new[] { AcpVersions.V1, AcpVersions.V2Alpha },
+
+            // Protocol-level
+            ["$/cancel_request"] = new[] { AcpVersions.V1, AcpVersions.V2Alpha }
+        };
+
+        /// <summary>
+        /// Whether <paramref name="method"/> exists in protocol <paramref name="version"/>.
+        /// Methods not in the registry (e.g. the nonstandard MCP-compat tools/*) are not
+        /// version-gated and return true.
+        /// </summary>
+        public static bool IsAvailable(string method, int version)
+        {
+            return !Methods.TryGetValue(method, out var versions) || Array.IndexOf(versions, version) >= 0;
+        }
+
+        /// <summary>Whether the registry knows <paramref name="method"/> at all.</summary>
+        public static bool IsKnown(string method) => Methods.ContainsKey(method);
+    }
+}

--- a/src/Andy.Acp.Core/Protocol/AcpProtocolHandler.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpProtocolHandler.cs
@@ -23,26 +23,37 @@ namespace Andy.Acp.Core.Protocol
         private readonly ServerInfo _serverInfo;
         private readonly AcpAgentCapabilities _agentCapabilities;
         private readonly IAuthenticationProvider? _authProvider;
+        private readonly System.Collections.Generic.IReadOnlySet<int> _supportedVersions;
+        private readonly V2.V2AgentCapabilities? _v2Capabilities;
         private readonly ILogger<AcpProtocolHandler>? _logger;
 
-        /// <summary>The highest ACP protocol version this agent supports (see <see cref="AcpVersions"/>).</summary>
-        public const int ProtocolVersion = AcpVersions.Current;
+        /// <summary>The default ACP protocol version (see <see cref="AcpVersions"/>).</summary>
+        public const int ProtocolVersion = AcpVersions.V1;
 
         /// <summary>The lowest ACP protocol version this agent supports (see <see cref="AcpVersions"/>).</summary>
-        public const int MinProtocolVersion = AcpVersions.Minimum;
+        public const int MinProtocolVersion = AcpVersions.V1;
 
         public AcpProtocolHandler(
             AcpConnectionState state,
             ServerInfo serverInfo,
             AcpAgentCapabilities agentCapabilities,
             ILogger<AcpProtocolHandler>? logger = null,
-            IAuthenticationProvider? authProvider = null)
+            IAuthenticationProvider? authProvider = null,
+            System.Collections.Generic.IReadOnlySet<int>? supportedVersions = null,
+            V2.V2AgentCapabilities? v2Capabilities = null)
         {
             _state = state ?? throw new ArgumentNullException(nameof(state));
             _serverInfo = serverInfo ?? throw new ArgumentNullException(nameof(serverInfo));
             _agentCapabilities = agentCapabilities ?? throw new ArgumentNullException(nameof(agentCapabilities));
             _authProvider = authProvider;
+            _supportedVersions = supportedVersions ?? AcpVersions.Default;
+            _v2Capabilities = v2Capabilities;
             _logger = logger;
+
+            if (_supportedVersions.Contains(AcpVersions.V2Alpha) && _v2Capabilities == null)
+                throw new ArgumentException(
+                    "v2 alpha is in the supported-version set but no v2 capabilities were supplied",
+                    nameof(v2Capabilities));
         }
 
         /// <summary>
@@ -83,6 +94,25 @@ namespace Andy.Acp.Core.Protocol
                 "Initialized: negotiated protocol version {Version} (client requested {Requested})",
                 negotiated, initParams.ProtocolVersion);
 
+            if (negotiated == AcpVersions.V2Alpha)
+            {
+                // v2 shape: required `info`, marker-object `capabilities`, `methodId` auth methods.
+                var v2Result = new V2.V2InitializeResult
+                {
+                    ProtocolVersion = negotiated,
+                    Info = new Implementation
+                    {
+                        Name = _serverInfo.Name,
+                        Version = _serverInfo.Version
+                    },
+                    Capabilities = _v2Capabilities,
+                    AuthMethods = _authProvider?.GetAuthMethods()
+                        .Select(m => new V2.V2AuthMethod { MethodId = m.Id, Name = m.Name, Description = m.Description })
+                        .ToList()
+                };
+                return Task.FromResult<object?>(v2Result);
+            }
+
             var result = new AcpInitializeResult
             {
                 ProtocolVersion = negotiated,
@@ -101,21 +131,16 @@ namespace Andy.Acp.Core.Protocol
         }
 
         /// <summary>
-        /// Applies the ACP version-negotiation rule: if the client's requested version is
-        /// supported it is used; a higher request is clamped down to this agent's maximum; a
-        /// lower unsupported request falls back to the agent's maximum so the client can decide.
+        /// Applies the ACP version-negotiation rule against the configured supported set:
+        /// a supported requested version is used as-is; anything else falls back to the
+        /// highest supported version so the client can decide whether to proceed.
         /// </summary>
-        private static int NegotiateVersion(int? requested)
+        private int NegotiateVersion(int? requested)
         {
-            if (!requested.HasValue)
-                return ProtocolVersion;
+            if (requested.HasValue && _supportedVersions.Contains(requested.Value))
+                return requested.Value;
 
-            int v = requested.Value;
-            if (v > ProtocolVersion)
-                return ProtocolVersion;
-            if (v < MinProtocolVersion)
-                return ProtocolVersion;
-            return v;
+            return _supportedVersions.Max();
         }
 
         /// <summary>
@@ -148,10 +173,15 @@ namespace Andy.Acp.Core.Protocol
             return new { };
         }
 
-        /// <summary>Handles the ACP <c>logout</c> request.</summary>
+        /// <summary>
+        /// Handles the ACP <c>logout</c> (v1) / <c>auth/logout</c> (v2) request. On v2,
+        /// non-empty authMethods imply mandatory logout support, so the SupportsLogout
+        /// opt-out only applies to v1 connections.
+        /// </summary>
         public async Task<object?> HandleLogoutAsync(object? parameters, CancellationToken cancellationToken = default)
         {
-            if (_authProvider == null || !_authProvider.SupportsLogout)
+            if (_authProvider == null ||
+                (!_authProvider.SupportsLogout && _state.ProtocolVersion != AcpVersions.V2Alpha))
                 throw new JsonRpcProtocolException(JsonRpcErrorCodes.MethodNotFound, "Logout is not supported");
 
             await _authProvider.LogoutAsync(cancellationToken).ConfigureAwait(false);
@@ -174,9 +204,18 @@ namespace Andy.Acp.Core.Protocol
 
             if (_authProvider != null)
             {
+                // v1 names. The method registry prevents these on v2-negotiated connections.
                 jsonRpcHandler.RegisterMethod("authenticate", HandleAuthenticateAsync);
                 if (_authProvider.SupportsLogout)
                     jsonRpcHandler.RegisterMethod("logout", HandleLogoutAsync);
+
+                // v2 names (same params: LoginAuthRequest.methodId matches, logout is empty).
+                // Only reachable on v2-negotiated connections via the method registry.
+                if (_supportedVersions.Contains(AcpVersions.V2Alpha))
+                {
+                    jsonRpcHandler.RegisterMethod("auth/login", HandleAuthenticateAsync);
+                    jsonRpcHandler.RegisterMethod("auth/logout", HandleLogoutAsync);
+                }
             }
 
             _logger?.LogInformation("Registered ACP protocol methods: initialize{Auth}",

--- a/src/Andy.Acp.Core/Protocol/AcpSessionHandler.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpSessionHandler.cs
@@ -103,7 +103,7 @@ namespace Andy.Acp.Core.Protocol
             }
         }
 
-        private async Task<object?> HandleNewSessionAsync(object? parameters, CancellationToken cancellationToken)
+        public async Task<object?> HandleNewSessionAsync(object? parameters, CancellationToken cancellationToken)
         {
             EnsureInitialized();
 
@@ -135,7 +135,7 @@ namespace Andy.Acp.Core.Protocol
             };
         }
 
-        private async Task<object?> HandleLoadSessionAsync(object? parameters, CancellationToken cancellationToken)
+        public async Task<object?> HandleLoadSessionAsync(object? parameters, CancellationToken cancellationToken)
         {
             EnsureInitialized();
 
@@ -178,11 +178,13 @@ namespace Andy.Acp.Core.Protocol
             };
         }
 
-        private async Task<object?> HandleSetConfigOptionAsync(object? parameters, CancellationToken cancellationToken)
+        public async Task<object?> HandleSetConfigOptionAsync(object? parameters, CancellationToken cancellationToken)
         {
             EnsureInitialized();
 
-            var configProvider = (ISessionConfigProvider)_agentProvider;
+            if (_agentProvider is not ISessionConfigProvider configProvider)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.MethodNotFound,
+                    "session/set_config_option is not supported by this agent");
             var req = DeserializeParams<SetConfigOptionRequest>(parameters);
 
             if (string.IsNullOrEmpty(req?.SessionId))
@@ -217,11 +219,13 @@ namespace Andy.Acp.Core.Protocol
             return new { configOptions = options };
         }
 
-        private async Task<object?> HandleListSessionsAsync(object? parameters, CancellationToken cancellationToken)
+        public async Task<object?> HandleListSessionsAsync(object? parameters, CancellationToken cancellationToken)
         {
             EnsureInitialized();
 
-            var catalog = (ISessionCatalogProvider)_agentProvider;
+            if (_agentProvider is not ISessionCatalogProvider catalog)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.MethodNotFound,
+                    "Session catalog methods are not supported by this agent");
             var req = DeserializeParams<ListSessionsRequest>(parameters) ?? new ListSessionsRequest();
 
             var result = await catalog.ListSessionsAsync(req.Cwd, req.Cursor, cancellationToken);
@@ -240,11 +244,13 @@ namespace Andy.Acp.Core.Protocol
             };
         }
 
-        private async Task<object?> HandleDeleteSessionAsync(object? parameters, CancellationToken cancellationToken)
+        public async Task<object?> HandleDeleteSessionAsync(object? parameters, CancellationToken cancellationToken)
         {
             EnsureInitialized();
 
-            var catalog = (ISessionCatalogProvider)_agentProvider;
+            if (_agentProvider is not ISessionCatalogProvider catalog)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.MethodNotFound,
+                    "Session catalog methods are not supported by this agent");
             var req = DeserializeParams<SessionIdRequest>(parameters);
 
             if (string.IsNullOrEmpty(req?.SessionId))
@@ -259,11 +265,13 @@ namespace Andy.Acp.Core.Protocol
             return new { };
         }
 
-        private async Task<object?> HandleResumeSessionAsync(object? parameters, CancellationToken cancellationToken)
+        public async Task<object?> HandleResumeSessionAsync(object? parameters, CancellationToken cancellationToken)
         {
             EnsureInitialized();
 
-            var catalog = (ISessionCatalogProvider)_agentProvider;
+            if (_agentProvider is not ISessionCatalogProvider catalog)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.MethodNotFound,
+                    "Session catalog methods are not supported by this agent");
             var req = DeserializeParams<LoadSessionRequest>(parameters);
 
             if (string.IsNullOrEmpty(req?.SessionId))
@@ -296,11 +304,13 @@ namespace Andy.Acp.Core.Protocol
             };
         }
 
-        private async Task<object?> HandleCloseSessionAsync(object? parameters, CancellationToken cancellationToken)
+        public async Task<object?> HandleCloseSessionAsync(object? parameters, CancellationToken cancellationToken)
         {
             EnsureInitialized();
 
-            var catalog = (ISessionCatalogProvider)_agentProvider;
+            if (_agentProvider is not ISessionCatalogProvider catalog)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.MethodNotFound,
+                    "Session catalog methods are not supported by this agent");
             var req = DeserializeParams<SessionIdRequest>(parameters);
 
             if (string.IsNullOrEmpty(req?.SessionId))
@@ -318,7 +328,7 @@ namespace Andy.Acp.Core.Protocol
             return new { };
         }
 
-        private async Task<object?> HandlePromptAsync(object? parameters, CancellationToken cancellationToken)
+        public async Task<object?> HandlePromptAsync(object? parameters, CancellationToken cancellationToken)
         {
             EnsureInitialized();
 
@@ -383,7 +393,7 @@ namespace Andy.Acp.Core.Protocol
             }
         }
 
-        private async Task<object?> HandleSetModeAsync(object? parameters, CancellationToken cancellationToken)
+        public async Task<object?> HandleSetModeAsync(object? parameters, CancellationToken cancellationToken)
         {
             EnsureInitialized();
 
@@ -405,7 +415,7 @@ namespace Andy.Acp.Core.Protocol
             return new { };
         }
 
-        private async Task<object?> HandleCancelAsync(object? parameters, CancellationToken cancellationToken)
+        public async Task<object?> HandleCancelAsync(object? parameters, CancellationToken cancellationToken)
         {
             var req = DeserializeParams<CancelRequest>(parameters);
 

--- a/src/Andy.Acp.Core/Protocol/AcpVersions.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpVersions.cs
@@ -1,26 +1,31 @@
+using System.Collections.Generic;
+
 namespace Andy.Acp.Core.Protocol
 {
     /// <summary>
     /// The single source of truth for the ACP protocol versions this library knows about.
-    /// All version constants, negotiation logic, and documentation must reference these
-    /// values — no other code may hardcode a protocol version number.
+    /// All version constants, negotiation logic, method gating, and documentation must
+    /// reference these values — no other code may hardcode a protocol version number.
     /// </summary>
     public static class AcpVersions
     {
         /// <summary>
-        /// Stable ACP v1 (pinned to schema-v1.20.0). This is the default and currently
-        /// the only version served.
+        /// Stable ACP v1 (pinned to schema-v1.20.0). This is the default version, and the
+        /// only one served unless v2 alpha is explicitly enabled.
         /// </summary>
         public const int V1 = 1;
 
         /// <summary>
-        /// The highest protocol version this library currently serves.
+        /// ACP v2 — **alpha** (pinned to schema-v2.0.0-alpha.x). Upstream may still make
+        /// breaking changes; serving it requires an explicit opt-in via
+        /// <c>AcpServerOptions.EnableV2Alpha</c>.
         /// </summary>
-        public const int Current = V1;
+        public const int V2Alpha = 2;
 
-        /// <summary>
-        /// The lowest protocol version this library currently serves.
-        /// </summary>
-        public const int Minimum = V1;
+        /// <summary>The versions served by default: stable v1 only.</summary>
+        public static readonly IReadOnlySet<int> Default = new HashSet<int> { V1 };
+
+        /// <summary>All versions this library is capable of serving.</summary>
+        public static readonly IReadOnlySet<int> All = new HashSet<int> { V1, V2Alpha };
     }
 }

--- a/src/Andy.Acp.Core/Protocol/V2/AcpSessionHandlerV2.cs
+++ b/src/Andy.Acp.Core/Protocol/V2/AcpSessionHandlerV2.cs
@@ -1,0 +1,481 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Agent;
+using Andy.Acp.Core.Client;
+using Andy.Acp.Core.JsonRpc;
+using Andy.Acp.Core.Transport;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Acp.Core.Protocol.V2
+{
+    /// <summary>
+    /// ACP v2 (alpha) session method implementations. Instances are invoked by the
+    /// version router in <c>AcpServer</c> only on connections that negotiated v2; they
+    /// map v2 wire shapes onto the same version-neutral provider abstractions
+    /// (<see cref="IAgentProvider"/> and the optional interfaces) used by v1.
+    /// Key v2 behaviors handled here: the prompt response is an empty ACK with the stop
+    /// reason delivered via <c>state_update</c>; <c>session/resume</c> with
+    /// <c>replayFrom: {"type":"start"}</c> takes the place of v1 <c>session/load</c>.
+    /// </summary>
+    public class AcpSessionHandlerV2
+    {
+        private readonly IAgentProvider _agentProvider;
+        private readonly AcpConnectionState _state;
+        private readonly ILogger? _logger;
+        private ITransport? _transport;
+        private IAcpClient? _client;
+
+        private readonly ConcurrentDictionary<string, CancellationTokenSource> _activePrompts = new();
+
+        public AcpSessionHandlerV2(
+            IAgentProvider agentProvider,
+            AcpConnectionState state,
+            ILogger? logger = null)
+        {
+            _agentProvider = agentProvider ?? throw new ArgumentNullException(nameof(agentProvider));
+            _state = state ?? throw new ArgumentNullException(nameof(state));
+            _logger = logger;
+        }
+
+        public void SetTransport(ITransport transport) => _transport = transport;
+        public void SetClient(IAcpClient client) => _client = client;
+
+        private void EnsureReady()
+        {
+            if (!_state.Initialized)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.SessionNotInitialized,
+                    "Connection is not initialized. Call initialize first.");
+            if (!_state.Authenticated)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.AuthRequired,
+                    "Authentication required. Call auth/login first.");
+        }
+
+        public async Task<object?> HandleNewSessionAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            EnsureReady();
+
+            var req = Deserialize<NewSessionRequestV2>(parameters);
+            if (string.IsNullOrEmpty(req?.Cwd))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "cwd is required");
+            if (!Path.IsPathRooted(req!.Cwd))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "cwd must be an absolute path");
+
+            ValidateMcpServers(req.McpServers);
+
+            var metadata = await _agentProvider.CreateSessionAsync(new NewSessionParams
+            {
+                Cwd = req.Cwd,
+                McpServers = req.McpServers ?? new List<McpServerConfig>(),
+                AdditionalDirectories = req.AdditionalDirectories
+            }, cancellationToken);
+
+            _logger?.LogInformation("Created new v2 session {SessionId}", metadata.SessionId);
+
+            // v2 NewSessionResponse: sessionId + optional configOptions. No modes.
+            return new
+            {
+                sessionId = metadata.SessionId,
+                configOptions = V2Wire.ConfigOptions(metadata.ConfigOptions)
+            };
+        }
+
+        public async Task<object?> HandleResumeSessionAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            EnsureReady();
+
+            var req = Deserialize<ResumeSessionRequestV2>(parameters);
+            if (string.IsNullOrEmpty(req?.SessionId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "sessionId is required");
+            if (string.IsNullOrEmpty(req!.Cwd))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "cwd is required");
+
+            ValidateMcpServers(req.McpServers);
+
+            bool replay = false;
+            if (req.ReplayFrom != null)
+            {
+                if (req.ReplayFrom.Type != "start")
+                    throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                        $"Unsupported replayFrom cursor type: {req.ReplayFrom.Type}");
+                replay = true;
+            }
+
+            var loadParams = new LoadSessionParams
+            {
+                SessionId = req.SessionId,
+                Cwd = req.Cwd,
+                McpServers = req.McpServers ?? new List<McpServerConfig>(),
+                AdditionalDirectories = req.AdditionalDirectories
+            };
+
+            SessionMetadata? metadata;
+            if (replay)
+            {
+                if (!_agentProvider.GetCapabilities().LoadSession)
+                    throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                        "This agent does not support history replay");
+
+                var streamer = new SessionUpdateStreamerV2(_transport, req.SessionId, _logger, _client);
+                metadata = await _agentProvider.LoadSessionAsync(loadParams, streamer, cancellationToken);
+            }
+            else if (_agentProvider is ISessionCatalogProvider catalog)
+            {
+                metadata = await catalog.ResumeSessionAsync(loadParams, cancellationToken);
+            }
+            else
+            {
+                // Resume without replay via the load path with a muted streamer, so agents
+                // that only implement LoadSessionAsync still support v2 resume.
+                var muted = new SessionUpdateStreamerV2(null, req.SessionId, _logger, _client);
+                metadata = await _agentProvider.LoadSessionAsync(loadParams, muted, cancellationToken);
+            }
+
+            if (metadata == null)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.ResourceNotFound,
+                    $"Session not found: {req.SessionId}");
+
+            return new { configOptions = V2Wire.ConfigOptions(metadata.ConfigOptions) };
+        }
+
+        public async Task<object?> HandleListSessionsAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            EnsureReady();
+
+            var req = Deserialize<ListSessionsRequestV2>(parameters) ?? new ListSessionsRequestV2();
+
+            if (_agentProvider is not ISessionCatalogProvider catalog)
+            {
+                // session/list is baseline in v2; agents without a catalog list nothing.
+                return new { sessions = Array.Empty<object>() };
+            }
+
+            var result = await catalog.ListSessionsAsync(req.Cwd, req.Cursor, cancellationToken);
+            return new
+            {
+                sessions = result.Sessions.Select(s => new
+                {
+                    sessionId = s.SessionId,
+                    cwd = s.Cwd,
+                    additionalDirectories = s.AdditionalDirectories,
+                    title = s.Title,
+                    updatedAt = s.UpdatedAt?.ToString("o")
+                }).ToArray(),
+                nextCursor = result.NextCursor
+            };
+        }
+
+        public async Task<object?> HandleDeleteSessionAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            EnsureReady();
+
+            if (_agentProvider is not ISessionCatalogProvider catalog)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.MethodNotFound,
+                    "session/delete is not supported by this agent");
+
+            var req = Deserialize<SessionIdRequestV2>(parameters);
+            if (string.IsNullOrEmpty(req?.SessionId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "sessionId is required");
+
+            if (!await catalog.DeleteSessionAsync(req!.SessionId, cancellationToken))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.ResourceNotFound,
+                    $"Session not found: {req.SessionId}");
+
+            return new { };
+        }
+
+        public async Task<object?> HandleCloseSessionAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            EnsureReady();
+
+            var req = Deserialize<SessionIdRequestV2>(parameters);
+            if (string.IsNullOrEmpty(req?.SessionId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "sessionId is required");
+
+            if (_activePrompts.TryGetValue(req!.SessionId, out var cts))
+            {
+                try { cts.Cancel(); } catch (ObjectDisposedException) { }
+            }
+
+            if (_agentProvider is ISessionCatalogProvider catalog)
+                await catalog.CloseSessionAsync(req.SessionId, cancellationToken);
+            else
+                await _agentProvider.CancelSessionAsync(req.SessionId, cancellationToken);
+
+            return new { };
+        }
+
+        public async Task<object?> HandleSetConfigOptionAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            EnsureReady();
+
+            if (_agentProvider is not ISessionConfigProvider configProvider)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.MethodNotFound,
+                    "session/set_config_option is not supported by this agent");
+
+            var req = Deserialize<SetConfigOptionRequestV2>(parameters);
+            if (string.IsNullOrEmpty(req?.SessionId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "sessionId is required");
+            if (string.IsNullOrEmpty(req!.ConfigId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "configId is required");
+            if (string.IsNullOrEmpty(req.Type))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "type is required");
+
+            // v2 value variants: "id" (select value id) or "boolean".
+            var value = new SessionConfigValue();
+            switch (req.Type)
+            {
+                case "id" when req.Value.ValueKind == JsonValueKind.String:
+                    value.ValueId = req.Value.GetString();
+                    break;
+                case "boolean" when req.Value.ValueKind is JsonValueKind.True or JsonValueKind.False:
+                    value.BoolValue = req.Value.GetBoolean();
+                    break;
+                default:
+                    throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                        $"Unsupported config value type: {req.Type}");
+            }
+
+            IReadOnlyList<SessionConfigOption> options;
+            try
+            {
+                options = await configProvider.SetConfigOptionAsync(req.SessionId, req.ConfigId, value, cancellationToken);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, ex.Message);
+            }
+
+            return new { configOptions = V2Wire.ConfigOptions(options) };
+        }
+
+        public async Task<object?> HandlePromptAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            EnsureReady();
+
+            var req = Deserialize<PromptRequestV2>(parameters);
+            if (string.IsNullOrEmpty(req?.SessionId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "Session ID is required");
+            if (req!.PromptBlocks == null || req.PromptBlocks.Count == 0)
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "Prompt content is required");
+
+            ValidateContentBlocks(req.PromptBlocks);
+
+            var message = new PromptMessage
+            {
+                Blocks = req.PromptBlocks,
+                Text = string.Join("\n", req.PromptBlocks
+                    .Where(b => b.Type == "text" && !string.IsNullOrEmpty(b.Text))
+                    .Select(b => b.Text!))
+            };
+
+            var promptCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            if (!_activePrompts.TryAdd(req.SessionId, promptCts))
+            {
+                promptCts.Dispose();
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidRequest,
+                    $"A prompt is already in progress for session {req.SessionId}");
+            }
+
+            var streamer = new SessionUpdateStreamerV2(_transport, req.SessionId, _logger, _client);
+            try
+            {
+                // v2: the turn's lifecycle is reported via state_update; the prompt
+                // response itself is an empty ACK sent after the idle state.
+                await streamer.SendStateRunningAsync(cancellationToken);
+
+                string stopReason;
+                try
+                {
+                    var response = await _agentProvider.ProcessPromptAsync(
+                        req.SessionId, message, streamer, promptCts.Token);
+                    stopReason = MapStopReason(response.StopReason);
+                }
+                catch (OperationCanceledException)
+                {
+                    stopReason = "cancelled";
+                }
+
+                await streamer.SendStateIdleAsync(stopReason, cancellationToken);
+                return new { };
+            }
+            finally
+            {
+                _activePrompts.TryRemove(req.SessionId, out _);
+                promptCts.Dispose();
+            }
+        }
+
+        public async Task<object?> HandleCancelAsync(object? parameters, CancellationToken cancellationToken)
+        {
+            var req = Deserialize<SessionIdRequestV2>(parameters);
+            if (string.IsNullOrEmpty(req?.SessionId))
+                throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams, "Session ID is required");
+
+            if (_activePrompts.TryGetValue(req!.SessionId, out var cts))
+            {
+                _logger?.LogInformation("Cancelling in-flight v2 prompt for session {SessionId}", req.SessionId);
+                try { cts.Cancel(); } catch (ObjectDisposedException) { }
+            }
+
+            await _agentProvider.CancelSessionAsync(req.SessionId, cancellationToken);
+            return null; // notification
+        }
+
+        /// <summary>
+        /// v2 MCP validation: <c>type</c> is required, <c>sse</c> no longer exists,
+        /// <c>http</c> requires the capability, and stdio is always accepted.
+        /// </summary>
+        private void ValidateMcpServers(List<McpServerConfig>? servers)
+        {
+            if (servers == null || servers.Count == 0)
+                return;
+
+            var caps = _agentProvider.GetCapabilities();
+            foreach (var server in servers)
+            {
+                switch (server.Type)
+                {
+                    case "stdio":
+                        break;
+                    case "http":
+                        if (!caps.McpHttp)
+                            throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                                $"HTTP MCP servers are not supported by this agent (server: {server.Name})");
+                        break;
+                    case null:
+                    case "":
+                        throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                            "McpServer.type is required in ACP v2");
+                    default:
+                        throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                            $"Unsupported MCP server type: {server.Type}");
+                }
+            }
+        }
+
+        private void ValidateContentBlocks(List<ContentBlock> blocks)
+        {
+            var caps = _agentProvider.GetCapabilities();
+            foreach (var block in blocks)
+            {
+                switch (block.Type)
+                {
+                    case "text":
+                    case "resource_link":
+                        break;
+                    case "image":
+                        if (!caps.ImagePrompts)
+                            throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                                "Image content is not supported by this agent");
+                        break;
+                    case "audio":
+                        if (!caps.AudioPrompts)
+                            throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                                "Audio content is not supported by this agent");
+                        break;
+                    case "resource":
+                        if (!caps.EmbeddedContext)
+                            throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                                "Embedded resource content is not supported by this agent");
+                        break;
+                    default:
+                        throw new JsonRpcProtocolException(JsonRpcErrorCodes.InvalidParams,
+                            $"Unsupported content block type: {block.Type}");
+                }
+            }
+        }
+
+        private static T? Deserialize<T>(object? parameters) where T : class
+        {
+            if (parameters == null)
+                return null;
+            if (parameters is JsonElement el)
+                return JsonSerializer.Deserialize<T>(el.GetRawText(), JsonRpcSerializer.Options);
+            var json = JsonSerializer.Serialize(parameters, JsonRpcSerializer.Options);
+            return JsonSerializer.Deserialize<T>(json, JsonRpcSerializer.Options);
+        }
+
+        private static string MapStopReason(StopReason stopReason) => stopReason switch
+        {
+            StopReason.Completed => "end_turn",
+            StopReason.Cancelled => "cancelled",
+            StopReason.TokenLimit => "max_tokens",
+            StopReason.Error => "refusal",
+            StopReason.TimeLimit => "max_tokens",
+            _ => "end_turn"
+        };
+
+        private class NewSessionRequestV2
+        {
+            [JsonPropertyName("cwd")]
+            public string? Cwd { get; set; }
+
+            [JsonPropertyName("additionalDirectories")]
+            public List<string>? AdditionalDirectories { get; set; }
+
+            [JsonPropertyName("mcpServers")]
+            public List<McpServerConfig>? McpServers { get; set; }
+        }
+
+        private class ResumeSessionRequestV2 : NewSessionRequestV2
+        {
+            [JsonPropertyName("sessionId")]
+            public string SessionId { get; set; } = string.Empty;
+
+            [JsonPropertyName("replayFrom")]
+            public ReplayFromV2? ReplayFrom { get; set; }
+        }
+
+        private class ReplayFromV2
+        {
+            [JsonPropertyName("type")]
+            public string Type { get; set; } = string.Empty;
+        }
+
+        private class ListSessionsRequestV2
+        {
+            [JsonPropertyName("cwd")]
+            public string? Cwd { get; set; }
+
+            [JsonPropertyName("cursor")]
+            public string? Cursor { get; set; }
+        }
+
+        private class SessionIdRequestV2
+        {
+            [JsonPropertyName("sessionId")]
+            public string SessionId { get; set; } = string.Empty;
+        }
+
+        private class SetConfigOptionRequestV2
+        {
+            [JsonPropertyName("sessionId")]
+            public string SessionId { get; set; } = string.Empty;
+
+            [JsonPropertyName("configId")]
+            public string ConfigId { get; set; } = string.Empty;
+
+            [JsonPropertyName("type")]
+            public string? Type { get; set; }
+
+            [JsonPropertyName("value")]
+            public JsonElement Value { get; set; }
+        }
+
+        private class PromptRequestV2
+        {
+            [JsonPropertyName("sessionId")]
+            public string SessionId { get; set; } = string.Empty;
+
+            [JsonPropertyName("prompt")]
+            public List<ContentBlock>? PromptBlocks { get; set; }
+        }
+    }
+}

--- a/src/Andy.Acp.Core/Protocol/V2/SessionUpdateStreamerV2.cs
+++ b/src/Andy.Acp.Core/Protocol/V2/SessionUpdateStreamerV2.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Agent;
+using Andy.Acp.Core.Client;
+using Andy.Acp.Core.JsonRpc;
+using Andy.Acp.Core.Transport;
+using Microsoft.Extensions.Logging;
+
+namespace Andy.Acp.Core.Protocol.V2
+{
+    /// <summary>
+    /// v2 implementation of <see cref="IResponseStreamer"/>: emits ACP v2 (alpha)
+    /// <c>session/update</c> variants. Differences from v1 handled here:
+    /// message chunks carry a required <c>messageId</c>; tool calls are upserts via
+    /// <c>tool_call_update</c> (no separate creation variant); plans are
+    /// <c>plan_update</c> with a <c>planId</c>; v1 diffs are mapped to the reworked v2
+    /// diff shape; turn state is reported via <c>state_update</c>.
+    /// </summary>
+    public class SessionUpdateStreamerV2 : IResponseStreamer
+    {
+        private readonly ITransport? _transport;
+        private readonly string _sessionId;
+        private readonly ILogger? _logger;
+        private readonly IAcpClient? _client;
+
+        // v2 requires a messageId on every content chunk. One id per role per turn keeps
+        // consecutive chunks appending to the same message.
+        private readonly string _messageId = Guid.NewGuid().ToString("N");
+        private readonly string _thoughtMessageId = Guid.NewGuid().ToString("N");
+        private readonly string _planId = Guid.NewGuid().ToString("N");
+
+        public SessionUpdateStreamerV2(
+            ITransport? transport,
+            string sessionId,
+            ILogger? logger = null,
+            IAcpClient? client = null)
+        {
+            _transport = transport;
+            _sessionId = sessionId ?? throw new ArgumentNullException(nameof(sessionId));
+            _logger = logger;
+            _client = client;
+        }
+
+        /// <inheritdoc />
+        public IAcpClient Client =>
+            _client ?? throw new InvalidOperationException(
+                "No ACP client is available in this context (agent-to-client requests require a live connection).");
+
+        public Task SendMessageChunkAsync(string text, CancellationToken cancellationToken)
+            => SendUpdateAsync(new
+            {
+                sessionUpdate = "agent_message_chunk",
+                messageId = _messageId,
+                content = new { type = "text", text }
+            }, cancellationToken);
+
+        public Task SendThinkingAsync(string thinking, CancellationToken cancellationToken)
+            => SendUpdateAsync(new
+            {
+                sessionUpdate = "agent_thought_chunk",
+                messageId = _thoughtMessageId,
+                content = new { type = "text", text = thinking }
+            }, cancellationToken);
+
+        public Task SendToolCallAsync(ToolCall toolCall, CancellationToken cancellationToken)
+            // v2 has no separate creation variant: the first upsert creates the call.
+            => SendUpdateAsync(new
+            {
+                sessionUpdate = "tool_call_update",
+                toolCallId = toolCall.Id,
+                title = string.IsNullOrEmpty(toolCall.Title) ? toolCall.Name : toolCall.Title,
+                kind = string.IsNullOrEmpty(toolCall.Kind) ? "other" : toolCall.Kind,
+                status = string.IsNullOrEmpty(toolCall.Status) ? "pending" : toolCall.Status,
+                rawInput = toolCall.Input,
+                locations = MapLocations(toolCall.Locations),
+                content = MapToolContent(toolCall.ContentItems)
+            }, cancellationToken);
+
+        public Task SendToolResultAsync(ToolResult result, CancellationToken cancellationToken)
+        {
+            object? content = MapToolContent(result.ContentItems);
+            if (content == null && result.Content != null)
+            {
+                content = new object[]
+                {
+                    new { type = "content", content = new { type = "text", text = result.Content } }
+                };
+            }
+
+            return SendUpdateAsync(new
+            {
+                sessionUpdate = "tool_call_update",
+                toolCallId = result.CallId,
+                status = result.IsError ? "failed" : "completed",
+                content,
+                rawOutput = result.RawOutput,
+                locations = MapLocations(result.Locations)
+            }, cancellationToken);
+        }
+
+        public Task SendExecutionPlanAsync(ExecutionPlan plan, CancellationToken cancellationToken)
+            => SendUpdateAsync(new
+            {
+                sessionUpdate = "plan_update",
+                plan = new
+                {
+                    type = "items",
+                    planId = _planId,
+                    entries = plan.ResolveEntries().Select(e => new
+                    {
+                        content = e.Content,
+                        priority = string.IsNullOrEmpty(e.Priority) ? "medium" : e.Priority,
+                        status = string.IsNullOrEmpty(e.Status) ? "pending" : e.Status
+                    }).ToArray()
+                }
+            }, cancellationToken);
+
+        public Task SendAvailableCommandsAsync(IReadOnlyList<AvailableCommand> commands, CancellationToken cancellationToken)
+            => SendUpdateAsync(new
+            {
+                sessionUpdate = "available_commands_update",
+                availableCommands = commands.Select(c => new
+                {
+                    name = c.Name,
+                    description = c.Description,
+                    input = c.InputHint == null ? null : new { hint = c.InputHint }
+                }).ToArray()
+            }, cancellationToken);
+
+        public Task SendCurrentModeAsync(string modeId, CancellationToken cancellationToken)
+            // v2 removed current_mode_update: modes are config options (category "mode").
+            => throw new NotSupportedException(
+                "ACP v2 has no current_mode_update; report mode changes via SendConfigOptionsAsync " +
+                "with a config option of category \"mode\".");
+
+        public Task SendConfigOptionsAsync(IReadOnlyList<SessionConfigOption> configOptions, CancellationToken cancellationToken)
+            => SendUpdateAsync(new
+            {
+                sessionUpdate = "config_option_update",
+                configOptions = V2Wire.ConfigOptions(configOptions)
+            }, cancellationToken);
+
+        public Task SendSessionInfoAsync(string? title, DateTimeOffset? updatedAt, CancellationToken cancellationToken)
+            => SendUpdateAsync(new
+            {
+                sessionUpdate = "session_info_update",
+                title,
+                updatedAt = updatedAt?.ToString("o")
+            }, cancellationToken);
+
+        public Task SendUsageAsync(long used, long size, UsageCost? cost, CancellationToken cancellationToken)
+            => SendUpdateAsync(new
+            {
+                sessionUpdate = "usage_update",
+                used,
+                size,
+                cost = cost == null ? null : new { amount = cost.Amount, currency = cost.Currency }
+            }, cancellationToken);
+
+        /// <summary>Emits <c>state_update</c> with <c>state: "running"</c>.</summary>
+        public Task SendStateRunningAsync(CancellationToken cancellationToken)
+            => SendUpdateAsync(new { sessionUpdate = "state_update", state = "running" }, cancellationToken);
+
+        /// <summary>
+        /// Emits <c>state_update</c> with <c>state: "idle"</c> carrying the stop reason —
+        /// in v2 this replaces the v1 PromptResponse stopReason.
+        /// </summary>
+        public Task SendStateIdleAsync(string stopReason, CancellationToken cancellationToken)
+            => SendUpdateAsync(new { sessionUpdate = "state_update", state = "idle", stopReason }, cancellationToken);
+
+        private static object? MapLocations(List<ToolCallLocation>? locations)
+        {
+            if (locations == null || locations.Count == 0)
+                return null;
+            return locations.Select(l => new { path = l.Path, line = l.Line }).ToArray();
+        }
+
+        /// <summary>
+        /// Maps provider tool content to v2 <c>ToolCallContent</c>. The v1-style
+        /// path/oldText/newText diff maps onto the v2 shape as a single change
+        /// (<c>add</c> when there was no old text, else <c>modify</c>); no patch text is
+        /// synthesized.
+        /// </summary>
+        private static object? MapToolContent(List<ToolCallContent>? items)
+        {
+            if (items == null || items.Count == 0)
+                return null;
+
+            return items.Select<ToolCallContent, object>(item => item.Type switch
+            {
+                "diff" => new
+                {
+                    type = "diff",
+                    changes = new object[]
+                    {
+                        new
+                        {
+                            operation = item.OldText == null ? "add" : "modify",
+                            path = item.Path ?? string.Empty
+                        }
+                    }
+                },
+                "terminal" => new
+                {
+                    type = "terminal",
+                    terminalId = item.TerminalId ?? string.Empty
+                },
+                _ => new
+                {
+                    type = "content",
+                    content = (object?)item.Content ?? new { type = "text", text = item.Text ?? string.Empty }
+                }
+            }).ToArray();
+        }
+
+        private async Task SendUpdateAsync(object update, CancellationToken cancellationToken)
+        {
+            if (_transport == null)
+            {
+                _logger?.LogWarning("Transport not set; dropping session/update notification");
+                return;
+            }
+
+            var notification = new
+            {
+                jsonrpc = "2.0",
+                method = "session/update",
+                @params = new { sessionId = _sessionId, update }
+            };
+
+            var json = System.Text.Json.JsonSerializer.Serialize(notification, JsonRpcSerializer.Options);
+            _logger?.LogTrace("Sending v2 session/update: {Notification}", json);
+
+            try
+            {
+                await _transport.WriteMessageAsync(json, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Failed to write session/update notification");
+                throw;
+            }
+        }
+    }
+}

--- a/src/Andy.Acp.Core/Protocol/V2/V2Models.cs
+++ b/src/Andy.Acp.Core/Protocol/V2/V2Models.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+using Andy.Acp.Core.Agent;
+
+namespace Andy.Acp.Core.Protocol.V2
+{
+    /// <summary>
+    /// ACP v2 (alpha) wire models. These deliberately live in their own namespace and are
+    /// never mixed with v1 types where the schemas differ. Version-neutral primitives
+    /// (<see cref="Implementation"/>, <see cref="CapabilityMarker"/>) are shared from the
+    /// v1 namespace because their shapes are identical in both versions.
+    /// </summary>
+    public class V2InitializeResult
+    {
+        [JsonPropertyName("protocolVersion")]
+        public int ProtocolVersion { get; set; } = AcpVersions.V2Alpha;
+
+        /// <summary>Agent implementation info — required in v2.</summary>
+        [JsonPropertyName("info")]
+        public Implementation Info { get; set; } = new();
+
+        [JsonPropertyName("capabilities")]
+        public V2AgentCapabilities? Capabilities { get; set; }
+
+        [JsonPropertyName("authMethods")]
+        public List<V2AuthMethod>? AuthMethods { get; set; }
+    }
+
+    /// <summary>v2 <c>InitializeRequest</c> parameters.</summary>
+    public class V2InitializeParams
+    {
+        [JsonPropertyName("protocolVersion")]
+        public int? ProtocolVersion { get; set; }
+
+        [JsonPropertyName("info")]
+        public Implementation? Info { get; set; }
+    }
+
+    /// <summary>v2 <c>AgentCapabilities</c>: marker-object style.</summary>
+    public class V2AgentCapabilities
+    {
+        [JsonPropertyName("session")]
+        public V2SessionCapabilities? Session { get; set; }
+    }
+
+    /// <summary>
+    /// v2 <c>SessionCapabilities</c>. Presence of this object advertises the baseline
+    /// session methods (new/list/resume/close/prompt/cancel); <c>delete</c> is gated by
+    /// its own marker.
+    /// </summary>
+    public class V2SessionCapabilities
+    {
+        [JsonPropertyName("prompt")]
+        public V2PromptCapabilities? Prompt { get; set; }
+
+        [JsonPropertyName("mcp")]
+        public V2McpCapabilities? Mcp { get; set; }
+
+        [JsonPropertyName("delete")]
+        public CapabilityMarker? Delete { get; set; }
+
+        [JsonPropertyName("additionalDirectories")]
+        public CapabilityMarker? AdditionalDirectories { get; set; }
+    }
+
+    /// <summary>v2 <c>PromptCapabilities</c>: booleans became markers.</summary>
+    public class V2PromptCapabilities
+    {
+        [JsonPropertyName("image")]
+        public CapabilityMarker? Image { get; set; }
+
+        [JsonPropertyName("audio")]
+        public CapabilityMarker? Audio { get; set; }
+
+        [JsonPropertyName("embeddedContext")]
+        public CapabilityMarker? EmbeddedContext { get; set; }
+    }
+
+    /// <summary>v2 <c>McpCapabilities</c>: explicit stdio + http markers (sse removed).</summary>
+    public class V2McpCapabilities
+    {
+        [JsonPropertyName("stdio")]
+        public CapabilityMarker? Stdio { get; set; }
+
+        [JsonPropertyName("http")]
+        public CapabilityMarker? Http { get; set; }
+    }
+
+    /// <summary>v2 <c>AuthMethod</c>: required <c>type</c> discriminator, <c>methodId</c> (was <c>id</c>).</summary>
+    public class V2AuthMethod
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = "agent";
+
+        [JsonPropertyName("methodId")]
+        public string MethodId { get; set; } = string.Empty;
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string? Description { get; set; }
+    }
+
+    /// <summary>
+    /// Maps version-neutral provider models to v2 wire shapes where field names differ
+    /// from v1 (config options: <c>configId</c>, <c>groupId</c>).
+    /// </summary>
+    public static class V2Wire
+    {
+        /// <summary>Maps a provider config option to the v2 wire shape.</summary>
+        public static object ConfigOption(SessionConfigOption o) => new
+        {
+            type = o.Type,
+            configId = o.Id,
+            name = o.Name,
+            description = o.Description,
+            category = o.Category,
+            currentValue = o.CurrentValue,
+            options = o.Type != "select"
+                ? null
+                : o.Groups is { Count: > 0 }
+                    ? o.Groups.Select(g => (object)new
+                    {
+                        groupId = g.Group,
+                        name = g.Name,
+                        options = g.Options.Select(SelectOption).ToArray()
+                    }).ToArray()
+                    : o.Options?.Select(SelectOption).ToArray()
+        };
+
+        /// <summary>Maps a provider config option list to the v2 wire shape (null-safe).</summary>
+        public static object[]? ConfigOptions(IEnumerable<SessionConfigOption>? options)
+            => options?.Select(ConfigOption).ToArray();
+
+        private static object SelectOption(SessionConfigSelectOption s) => new
+        {
+            value = s.Value,
+            name = s.Name,
+            description = s.Description
+        };
+    }
+}

--- a/src/Andy.Acp.Core/Server/AcpServer.cs
+++ b/src/Andy.Acp.Core/Server/AcpServer.cs
@@ -10,6 +10,7 @@ using Andy.Acp.Core.JsonRpc;
 using Andy.Acp.Core.Protocol;
 using Andy.Acp.Core.Session;
 using Andy.Acp.Core.Transport;
+using V2 = Andy.Acp.Core.Protocol.V2;
 using Microsoft.Extensions.Logging;
 
 namespace Andy.Acp.Core.Server
@@ -22,6 +23,7 @@ namespace Andy.Acp.Core.Server
     {
         private readonly IAgentProvider _agentProvider;
         private readonly ServerInfo _serverInfo;
+        private readonly AcpServerOptions _options;
         private readonly ILoggerFactory? _loggerFactory;
         private readonly ILogger<AcpServer>? _logger;
 
@@ -37,12 +39,16 @@ namespace Andy.Acp.Core.Server
         /// <param name="agentProvider">Required: The agent that handles prompts and reasoning</param>
         /// <param name="serverInfo">Optional: Server identification information</param>
         /// <param name="loggerFactory">Optional: Logger factory for diagnostics</param>
+        /// <param name="options">Optional: server options, including the protocol-version opt-in
+        /// (<see cref="AcpServerOptions.EnableV2Alpha"/>). Defaults to serving stable v1 only.</param>
         public AcpServer(
             IAgentProvider agentProvider,
             ServerInfo? serverInfo = null,
-            ILoggerFactory? loggerFactory = null)
+            ILoggerFactory? loggerFactory = null,
+            AcpServerOptions? options = null)
         {
             _agentProvider = agentProvider ?? throw new ArgumentNullException(nameof(agentProvider));
+            _options = options ?? new AcpServerOptions();
             _loggerFactory = loggerFactory;
             _logger = loggerFactory?.CreateLogger<AcpServer>();
 
@@ -126,8 +132,33 @@ namespace Andy.Acp.Core.Server
                         : null
                 };
 
+                // v2 (alpha) capabilities are built only when the host opted in.
+                V2.V2AgentCapabilities? v2Capabilities = null;
+                if (_options.EnableV2Alpha)
+                {
+                    v2Capabilities = new V2.V2AgentCapabilities
+                    {
+                        Session = new V2.V2SessionCapabilities
+                        {
+                            Prompt = new V2.V2PromptCapabilities
+                            {
+                                Image = agentCapabilities.ImagePrompts ? new CapabilityMarker() : null,
+                                Audio = agentCapabilities.AudioPrompts ? new CapabilityMarker() : null,
+                                EmbeddedContext = agentCapabilities.EmbeddedContext ? new CapabilityMarker() : null
+                            },
+                            Mcp = new V2.V2McpCapabilities
+                            {
+                                Stdio = new CapabilityMarker(), // stdio is always accepted
+                                Http = agentCapabilities.McpHttp ? new CapabilityMarker() : null
+                            },
+                            Delete = _agentProvider is ISessionCatalogProvider ? new CapabilityMarker() : null,
+                            AdditionalDirectories = agentCapabilities.AdditionalDirectories ? new CapabilityMarker() : null
+                        }
+                    };
+                }
+
                 // Shared connection state enforces initialize-before-session ordering and
-                // carries the negotiated client capabilities.
+                // carries the negotiated protocol version and client capabilities.
                 var connectionState = new AcpConnectionState();
 
                 // Register the initialize handshake handler (plus authenticate/logout when
@@ -137,7 +168,9 @@ namespace Andy.Acp.Core.Server
                     _serverInfo,
                     acpAgentCapabilities,
                     _loggerFactory?.CreateLogger<AcpProtocolHandler>(),
-                    authProvider);
+                    authProvider,
+                    _options.SupportedVersions,
+                    v2Capabilities);
                 protocolHandler.RegisterMethods(jsonRpcHandler);
 
                 // Agent → client request channel (fs/*, terminal/*, session/request_permission).
@@ -153,6 +186,42 @@ namespace Andy.Acp.Core.Server
                 sessionHandler.SetTransport(transport);  // Enable sending session/update notifications
                 sessionHandler.SetClient(acpClient);     // Enable agent-to-client requests
                 sessionHandler.RegisterMethods();
+
+                // When v2 alpha is enabled, register per-method version routers: shared
+                // method names dispatch to the v1 or v2 implementation based on the
+                // connection's negotiated version. v1-only methods (session/load,
+                // session/set_mode, authenticate, logout) stay registered as-is and are
+                // blocked on v2 connections by the AcpMethodRegistry gate in the dispatch
+                // path; likewise v2-only methods on v1 connections.
+                if (_options.EnableV2Alpha)
+                {
+                    var v2SessionHandler = new V2.AcpSessionHandlerV2(
+                        _agentProvider,
+                        connectionState,
+                        _loggerFactory?.CreateLogger<V2.AcpSessionHandlerV2>());
+                    v2SessionHandler.SetTransport(transport);
+                    v2SessionHandler.SetClient(acpClient);
+
+                    JsonRpcMethodDelegate Route(JsonRpcMethodDelegate v1, JsonRpcMethodDelegate v2) =>
+                        (p, ct) => connectionState.ProtocolVersion == AcpVersions.V2Alpha ? v2(p, ct) : v1(p, ct);
+
+                    jsonRpcHandler.RegisterMethod("session/new",
+                        Route(sessionHandler.HandleNewSessionAsync, v2SessionHandler.HandleNewSessionAsync));
+                    jsonRpcHandler.RegisterMethod("session/prompt",
+                        Route(sessionHandler.HandlePromptAsync, v2SessionHandler.HandlePromptAsync));
+                    jsonRpcHandler.RegisterMethod("session/cancel",
+                        Route(sessionHandler.HandleCancelAsync, v2SessionHandler.HandleCancelAsync));
+                    jsonRpcHandler.RegisterMethod("session/set_config_option",
+                        Route(sessionHandler.HandleSetConfigOptionAsync, v2SessionHandler.HandleSetConfigOptionAsync));
+                    jsonRpcHandler.RegisterMethod("session/list",
+                        Route(sessionHandler.HandleListSessionsAsync, v2SessionHandler.HandleListSessionsAsync));
+                    jsonRpcHandler.RegisterMethod("session/delete",
+                        Route(sessionHandler.HandleDeleteSessionAsync, v2SessionHandler.HandleDeleteSessionAsync));
+                    jsonRpcHandler.RegisterMethod("session/resume",
+                        Route(sessionHandler.HandleResumeSessionAsync, v2SessionHandler.HandleResumeSessionAsync));
+                    jsonRpcHandler.RegisterMethod("session/close",
+                        Route(sessionHandler.HandleCloseSessionAsync, v2SessionHandler.HandleCloseSessionAsync));
+                }
 
                 // Filesystem and terminal are agent → client requests, so no inbound fs/*
                 // or terminal/* handlers are registered here.
@@ -208,7 +277,7 @@ namespace Andy.Acp.Core.Server
                         // Dispatch handling without blocking the read loop. Failures are
                         // observed in the continuation and never terminate the loop silently.
                         var handlerTask = Task.Run(
-                            () => DispatchMessageAsync(messageJson, jsonRpcHandler, transport, acpClient, cancellationToken),
+                            () => DispatchMessageAsync(messageJson, jsonRpcHandler, transport, acpClient, connectionState, cancellationToken),
                             CancellationToken.None);
 
                         inFlight.TryAdd(handlerTask, 0);
@@ -263,6 +332,7 @@ namespace Andy.Acp.Core.Server
             JsonRpcHandler jsonRpcHandler,
             ITransport transport,
             AcpClient acpClient,
+            AcpConnectionState connectionState,
             CancellationToken cancellationToken)
         {
             JsonRpcResponse? response = null;
@@ -275,6 +345,25 @@ namespace Andy.Acp.Core.Server
                 {
                     _logger?.LogDebug("Processing {Kind}: {Method} (ID: {Id})",
                         request.IsNotification ? "notification" : "request", request.Method, request.Id);
+
+                    // Central version gate: once a version is negotiated, methods that do
+                    // not exist in it are rejected here, regardless of registration.
+                    if (connectionState.Initialized &&
+                        !AcpMethodRegistry.IsAvailable(request.Method, connectionState.ProtocolVersion))
+                    {
+                        _logger?.LogWarning("Method {Method} not available in negotiated protocol version {Version}",
+                            request.Method, connectionState.ProtocolVersion);
+
+                        if (!request.IsNotification)
+                        {
+                            var gateError = JsonRpcSerializer.CreateErrorResponse(
+                                request,
+                                JsonRpcErrorCodes.MethodNotFound,
+                                $"Method '{request.Method}' is not available in negotiated protocol version {connectionState.ProtocolVersion}");
+                            await WriteResponseAsync(transport, gateError, cancellationToken).ConfigureAwait(false);
+                        }
+                        return;
+                    }
 
                     if (request.Method == "$/cancel_request")
                     {
@@ -323,21 +412,24 @@ namespace Andy.Acp.Core.Server
             }
 
             if (response != null)
+                await WriteResponseAsync(transport, response, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task WriteResponseAsync(ITransport transport, JsonRpcResponse response, CancellationToken cancellationToken)
+        {
+            try
             {
-                try
-                {
-                    var responseJson = JsonRpcSerializer.Serialize(response);
-                    await transport.WriteMessageAsync(responseJson, cancellationToken).ConfigureAwait(false);
-                    _logger?.LogTrace("Sent response: {ResponseLength} bytes", responseJson.Length);
-                }
-                catch (OperationCanceledException)
-                {
-                    // Shutting down; nothing to write.
-                }
-                catch (Exception ex)
-                {
-                    _logger?.LogWarning(ex, "Failed to write response");
-                }
+                var responseJson = JsonRpcSerializer.Serialize(response);
+                await transport.WriteMessageAsync(responseJson, cancellationToken).ConfigureAwait(false);
+                _logger?.LogTrace("Sent response: {ResponseLength} bytes", responseJson.Length);
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutting down; nothing to write.
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "Failed to write response");
             }
         }
 

--- a/src/Andy.Acp.Core/Server/AcpServerOptions.cs
+++ b/src/Andy.Acp.Core/Server/AcpServerOptions.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using Andy.Acp.Core.Protocol;
+
+namespace Andy.Acp.Core.Server
+{
+    /// <summary>
+    /// Configuration for <see cref="AcpServer"/>. The protocol-version choice is made
+    /// here and nowhere else.
+    /// </summary>
+    public class AcpServerOptions
+    {
+        /// <summary>
+        /// Opt-in for ACP v2 (**alpha**). Off by default: the server then speaks stable v1
+        /// only, and a client requesting v2 is negotiated down to v1. When enabled, the
+        /// server serves both v1 and v2, and a connection's version is fixed by the
+        /// initialize negotiation. v2 is alpha upstream and may change incompatibly.
+        /// </summary>
+        public bool EnableV2Alpha { get; set; }
+
+        /// <summary>The resulting set of protocol versions this server will serve.</summary>
+        public IReadOnlySet<int> SupportedVersions =>
+            EnableV2Alpha ? AcpVersions.All : AcpVersions.Default;
+    }
+}

--- a/tests/Andy.Acp.Tests/Andy.Acp.Tests.csproj
+++ b/tests/Andy.Acp.Tests/Andy.Acp.Tests.csproj
@@ -17,8 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Pinned stable ACP v1 JSON Schema, vendored for conformance tests. -->
+    <!-- Pinned ACP JSON Schemas, vendored for conformance tests:
+         v1 = stable schema-v1.20.0; v2 = alpha schema-v2.0.0-alpha.x. -->
     <None Include="Schema\acp-v1-schema.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Schema\acp-v2-schema.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Andy.Acp.Tests/Protocol/V2/V2ProtocolTests.cs
+++ b/tests/Andy.Acp.Tests/Protocol/V2/V2ProtocolTests.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Agent;
+using Andy.Acp.Core.JsonRpc;
+using Andy.Acp.Core.Protocol;
+using Andy.Acp.Core.Protocol.V2;
+using Andy.Acp.Core.Server;
+using Andy.Acp.Tests.Schema;
+using Andy.Acp.Tests.Server;
+using Xunit;
+
+namespace Andy.Acp.Tests.Protocol.V2
+{
+    /// <summary>
+    /// Epic #30 tests: version negotiation matrix (#27), the v2 alpha method surface
+    /// (#28), and v2 schema validation plus cross-version behavior (#29).
+    /// </summary>
+    public class V2ProtocolTests
+    {
+        // ---- negotiation matrix (#27) ----------------------------------------------
+
+        private static (AcpProtocolHandler handler, AcpConnectionState state) Handler(bool v2)
+        {
+            var state = new AcpConnectionState();
+            var handler = new AcpProtocolHandler(
+                state,
+                new ServerInfo { Name = "T", Version = "1.0" },
+                new AcpAgentCapabilities(),
+                supportedVersions: v2 ? AcpVersions.All : AcpVersions.Default,
+                v2Capabilities: v2 ? new V2AgentCapabilities { Session = new V2SessionCapabilities() } : null);
+            return (handler, state);
+        }
+
+        private static JsonElement Params(object o) =>
+            JsonDocument.Parse(JsonSerializer.Serialize(o, JsonRpcSerializer.Options)).RootElement.Clone();
+
+        [Theory]
+        [InlineData(false, 1, 1)] // v1-only server, v1 request -> v1
+        [InlineData(false, 2, 1)] // v1-only server, v2 request -> negotiated down to v1
+        [InlineData(true, 1, 1)]  // v1+v2 server, v1 request -> v1
+        [InlineData(true, 2, 2)]  // v1+v2 server, v2 request -> v2
+        [InlineData(true, 99, 2)] // unsupported request -> highest supported
+        public async Task Negotiation_Matrix(bool v2Enabled, int requested, int expected)
+        {
+            var (handler, state) = Handler(v2Enabled);
+
+            var result = await handler.HandleInitializeAsync(Params(new { protocolVersion = requested }));
+
+            Assert.Equal(expected, state.ProtocolVersion);
+            var json = JsonSerializer.Serialize(result, result!.GetType(), JsonRpcSerializer.Options);
+            Assert.Equal(expected, JsonDocument.Parse(json).RootElement.GetProperty("protocolVersion").GetInt32());
+        }
+
+        [Fact]
+        public async Task V2Initialize_ResponseIsV2ShapedAndSchemaValid()
+        {
+            var (handler, _) = Handler(v2: true);
+
+            var result = await handler.HandleInitializeAsync(Params(new
+            {
+                protocolVersion = 2,
+                info = new { name = "client", version = "1.0" }
+            }));
+
+            var json = JsonSerializer.Serialize(result, result!.GetType(), JsonRpcSerializer.Options);
+            AcpSchema.AssertValidV2("InitializeResponse", json);
+
+            var root = JsonDocument.Parse(json).RootElement;
+            // v2 shape: `info` required, no v1 `agentInfo`/`agentCapabilities` members.
+            Assert.True(root.TryGetProperty("info", out _));
+            Assert.False(root.TryGetProperty("agentInfo", out _));
+            Assert.False(root.TryGetProperty("agentCapabilities", out _));
+        }
+
+        [Fact]
+        public async Task V1Initialize_OnV2EnabledServer_KeepsV1Shape()
+        {
+            var (handler, _) = Handler(v2: true);
+
+            var result = await handler.HandleInitializeAsync(Params(new { protocolVersion = 1 }));
+
+            var json = JsonSerializer.Serialize(result, result!.GetType(), JsonRpcSerializer.Options);
+            AcpSchema.AssertValid("InitializeResponse", json);
+            Assert.True(JsonDocument.Parse(json).RootElement.TryGetProperty("agentInfo", out _));
+        }
+
+        // ---- e2e v2 flow + version gating (#28, #29) --------------------------------
+
+        [Fact]
+        public async Task V2PromptFlow_StateUpdatesAndEmptyAck_AllSchemaValid()
+        {
+            var harness = new InMemoryDuplex();
+            var server = new AcpServer(new V2Agent(), options: new AcpServerOptions { EnableV2Alpha = true });
+
+            using var cts = new CancellationTokenSource();
+            var serverTask = server.RunAsync(harness.ServerTransport, cts.Token);
+
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":2,"info":{"name":"c","version":"1"}}}""");
+            var initJson = await harness.ReadMessageAsync();
+            AcpSchema.AssertValidV2("InitializeResponse",
+                JsonDocument.Parse(initJson).RootElement.GetProperty("result").GetRawText());
+
+            // v2: mcpServers is optional on session/new.
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/tmp"}}""");
+            var newDoc = JsonDocument.Parse(await harness.ReadMessageAsync());
+            AcpSchema.AssertValidV2("NewSessionResponse", newDoc.RootElement.GetProperty("result").GetRawText());
+            var sid = newDoc.RootElement.GetProperty("result").GetProperty("sessionId").GetString();
+
+            await harness.SendAsync(
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/prompt\",\"params\":{\"sessionId\":\"" +
+                sid + "\",\"prompt\":[{\"type\":\"text\",\"text\":\"hi\"}]}}");
+
+            var states = new List<string>();
+            string? chunkMessageId = null;
+            string? idleStopReason = null;
+            JsonElement? promptResult = null;
+
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            while (promptResult == null)
+            {
+                var root = JsonDocument.Parse(await harness.ReadMessageAsync(timeout.Token)).RootElement.Clone();
+                if (root.TryGetProperty("method", out var m) && m.GetString() == "session/update")
+                {
+                    AcpSchema.AssertValidV2("UpdateSessionNotification", root.GetProperty("params").GetRawText());
+                    var update = root.GetProperty("params").GetProperty("update");
+                    var kind = update.GetProperty("sessionUpdate").GetString()!;
+                    if (kind == "state_update")
+                    {
+                        states.Add(update.GetProperty("state").GetString()!);
+                        if (update.TryGetProperty("stopReason", out var sr))
+                            idleStopReason = sr.GetString();
+                    }
+                    else if (kind == "agent_message_chunk")
+                    {
+                        chunkMessageId = update.GetProperty("messageId").GetString();
+                    }
+                }
+                else if (root.TryGetProperty("id", out var id) && id.ValueKind == JsonValueKind.Number && id.GetInt64() == 2)
+                {
+                    promptResult = root.GetProperty("result").Clone();
+                }
+            }
+
+            // v2 lifecycle: running -> ... -> idle(stopReason); the response is an empty ACK.
+            Assert.Equal(new[] { "running", "idle" }, states);
+            Assert.Equal("end_turn", idleStopReason);
+            Assert.False(string.IsNullOrEmpty(chunkMessageId));
+            Assert.False(promptResult.Value.TryGetProperty("stopReason", out _));
+
+            cts.Cancel();
+            harness.Complete();
+            try { await serverTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
+        }
+
+        [Fact]
+        public async Task VersionGating_V1MethodOnV2Connection_IsMethodNotFound()
+        {
+            var harness = new InMemoryDuplex();
+            var server = new AcpServer(new V2Agent(), options: new AcpServerOptions { EnableV2Alpha = true });
+
+            using var cts = new CancellationTokenSource();
+            var serverTask = server.RunAsync(harness.ServerTransport, cts.Token);
+
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":2,"info":{"name":"c","version":"1"}}}""");
+            await harness.ReadMessageAsync();
+
+            // session/load and session/set_mode do not exist in v2.
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":1,"method":"session/load","params":{"sessionId":"s","cwd":"/tmp","mcpServers":[]}}""");
+            var doc = JsonDocument.Parse(await harness.ReadMessageAsync());
+            Assert.Equal(JsonRpcErrorCodes.MethodNotFound, doc.RootElement.GetProperty("error").GetProperty("code").GetInt32());
+
+            cts.Cancel();
+            harness.Complete();
+            try { await serverTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
+        }
+
+        [Fact]
+        public async Task VersionGating_V2MethodOnV1Connection_IsMethodNotFound()
+        {
+            var harness = new InMemoryDuplex();
+            var server = new AcpServer(new V2Agent(), options: new AcpServerOptions { EnableV2Alpha = true });
+
+            using var cts = new CancellationTokenSource();
+            var serverTask = server.RunAsync(harness.ServerTransport, cts.Token);
+
+            // Negotiate v1 on the v2-capable server.
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":1}}""");
+            await harness.ReadMessageAsync();
+
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":1,"method":"auth/login","params":{"methodId":"x"}}""");
+            var doc = JsonDocument.Parse(await harness.ReadMessageAsync());
+            Assert.Equal(JsonRpcErrorCodes.MethodNotFound, doc.RootElement.GetProperty("error").GetProperty("code").GetInt32());
+
+            cts.Cancel();
+            harness.Complete();
+            try { await serverTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
+        }
+
+        [Fact]
+        public async Task CrossVersion_V1ClientOnV2EnabledServer_GetsV1Behavior()
+        {
+            var harness = new InMemoryDuplex();
+            var server = new AcpServer(new V2Agent(), options: new AcpServerOptions { EnableV2Alpha = true });
+
+            using var cts = new CancellationTokenSource();
+            var serverTask = server.RunAsync(harness.ServerTransport, cts.Token);
+
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":1}}""");
+            await harness.ReadMessageAsync();
+
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/tmp","mcpServers":[]}}""");
+            var sid = JsonDocument.Parse(await harness.ReadMessageAsync())
+                .RootElement.GetProperty("result").GetProperty("sessionId").GetString();
+
+            await harness.SendAsync(
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"session/prompt\",\"params\":{\"sessionId\":\"" +
+                sid + "\",\"prompt\":[{\"type\":\"text\",\"text\":\"hi\"}]}}");
+
+            // v1 behavior: the prompt response itself carries stopReason.
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            while (true)
+            {
+                var root = JsonDocument.Parse(await harness.ReadMessageAsync(timeout.Token)).RootElement;
+                if (root.TryGetProperty("id", out var id) && id.ValueKind == JsonValueKind.Number && id.GetInt64() == 2)
+                {
+                    Assert.Equal("end_turn", root.GetProperty("result").GetProperty("stopReason").GetString());
+                    break;
+                }
+            }
+
+            cts.Cancel();
+            harness.Complete();
+            try { await serverTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
+        }
+
+        // ---- v2 streamer wire shapes (#29) ------------------------------------------
+
+        [Fact]
+        public async Task V2Streamer_PlanUpdate_IsSchemaValid()
+        {
+            var (streamer, transport) = V2Streamer();
+            await streamer.SendExecutionPlanAsync(new ExecutionPlan
+            {
+                Entries = new List<PlanEntry> { new() { Content = "step", Priority = "high", Status = "pending" } }
+            }, CancellationToken.None);
+
+            var p = ParamsOf(transport.Messages[0]);
+            AcpSchema.AssertValidV2("UpdateSessionNotification", p);
+            var plan = JsonDocument.Parse(p).RootElement.GetProperty("update").GetProperty("plan");
+            Assert.Equal("items", plan.GetProperty("type").GetString());
+            Assert.False(string.IsNullOrEmpty(plan.GetProperty("planId").GetString()));
+        }
+
+        [Fact]
+        public async Task V2Streamer_ToolCallWithDiff_MapsToV2DiffShape()
+        {
+            var (streamer, transport) = V2Streamer();
+            await streamer.SendToolCallAsync(new ToolCall
+            {
+                Id = "tc1",
+                Name = "edit",
+                Kind = "edit",
+                ContentItems = new List<ToolCallContent>
+                {
+                    new() { Type = "diff", Path = "/a.cs", OldText = "old", NewText = "new" }
+                }
+            }, CancellationToken.None);
+
+            var p = ParamsOf(transport.Messages[0]);
+            AcpSchema.AssertValidV2("UpdateSessionNotification", p);
+            var update = JsonDocument.Parse(p).RootElement.GetProperty("update");
+            // v2 has no tool_call variant: creation is the first tool_call_update.
+            Assert.Equal("tool_call_update", update.GetProperty("sessionUpdate").GetString());
+            var change = update.GetProperty("content")[0].GetProperty("changes")[0];
+            Assert.Equal("modify", change.GetProperty("operation").GetString());
+            Assert.Equal("/a.cs", change.GetProperty("path").GetString());
+        }
+
+        [Fact]
+        public async Task V2Streamer_ConfigOptions_UseConfigIdAndGroupId()
+        {
+            var (streamer, transport) = V2Streamer();
+            await streamer.SendConfigOptionsAsync(new List<SessionConfigOption>
+            {
+                new()
+                {
+                    Type = "select",
+                    Id = "model",
+                    Name = "Model",
+                    CurrentValueId = "m1",
+                    Groups = new List<SessionConfigSelectGroup>
+                    {
+                        new()
+                        {
+                            Group = "g1",
+                            Name = "Group",
+                            Options = new List<SessionConfigSelectOption> { new() { Value = "m1", Name = "M1" } }
+                        }
+                    }
+                }
+            }, CancellationToken.None);
+
+            var p = ParamsOf(transport.Messages[0]);
+            AcpSchema.AssertValidV2("UpdateSessionNotification", p);
+            var option = JsonDocument.Parse(p).RootElement.GetProperty("update").GetProperty("configOptions")[0];
+            Assert.Equal("model", option.GetProperty("configId").GetString());
+            Assert.False(option.TryGetProperty("id", out _)); // v1 field name must not leak
+            Assert.Equal("g1", option.GetProperty("options")[0].GetProperty("groupId").GetString());
+        }
+
+        [Fact]
+        public async Task V2Streamer_CurrentMode_IsNotSupported()
+        {
+            var (streamer, _) = V2Streamer();
+            await Assert.ThrowsAsync<NotSupportedException>(
+                () => streamer.SendCurrentModeAsync("chat", CancellationToken.None));
+        }
+
+        private static (SessionUpdateStreamerV2 streamer, CapturingTransport transport) V2Streamer()
+        {
+            var transport = new CapturingTransport();
+            return (new SessionUpdateStreamerV2(transport, "s1"), transport);
+        }
+
+        private static string ParamsOf(string notificationJson)
+            => JsonDocument.Parse(notificationJson).RootElement.GetProperty("params").GetRawText();
+
+        /// <summary>Streaming agent used across the v2 flow tests.</summary>
+        private sealed class V2Agent : IAgentProvider
+        {
+            public async Task<AgentResponse> ProcessPromptAsync(string sessionId, PromptMessage prompt, IResponseStreamer streamer, CancellationToken ct)
+            {
+                await streamer.SendMessageChunkAsync("Hello", ct);
+                return new AgentResponse { StopReason = StopReason.Completed };
+            }
+
+            public Task<SessionMetadata> CreateSessionAsync(NewSessionParams? parameters, CancellationToken ct)
+                => Task.FromResult(new SessionMetadata { SessionId = "s1" });
+            public Task<SessionMetadata?> LoadSessionAsync(LoadSessionParams parameters, IResponseStreamer streamer, CancellationToken ct)
+                => Task.FromResult<SessionMetadata?>(null);
+            public Task CancelSessionAsync(string sessionId, CancellationToken ct) => Task.CompletedTask;
+            public Task<bool> SetSessionModeAsync(string sessionId, string modeId, CancellationToken ct) => Task.FromResult(true);
+            public AgentCapabilities GetCapabilities() => new();
+        }
+
+        private sealed class CapturingTransport : Andy.Acp.Core.Transport.ITransport
+        {
+            public List<string> Messages { get; } = new();
+            public bool IsConnected => true;
+            public Task<string> ReadMessageAsync(CancellationToken cancellationToken = default) => Task.FromResult(string.Empty);
+            public Task WriteMessageAsync(string message, CancellationToken cancellationToken = default)
+            {
+                Messages.Add(message);
+                return Task.CompletedTask;
+            }
+            public Task CloseAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public void Dispose() { }
+        }
+    }
+}

--- a/tests/Andy.Acp.Tests/Schema/AcpSchema.cs
+++ b/tests/Andy.Acp.Tests/Schema/AcpSchema.cs
@@ -15,31 +15,51 @@ namespace Andy.Acp.Tests.Schema
     public static class AcpSchema
     {
         private const string BaseUri = "https://agentclientprotocol.dev/schema/v1";
+        private const string BaseUriV2 = "https://agentclientprotocol.dev/schema/v2";
         private static readonly EvaluationOptions Options;
 
         static AcpSchema()
         {
-            var path = Path.Combine(AppContext.BaseDirectory, "Schema", "acp-v1-schema.json");
-            var schema = JsonSchema.FromText(File.ReadAllText(path));
             Options = new EvaluationOptions { OutputFormat = OutputFormat.List };
-            Options.SchemaRegistry.Register(new Uri(BaseUri), schema);
+            Register(BaseUri, "acp-v1-schema.json");
+            Register(BaseUriV2, "acp-v2-schema.json");
         }
 
-        /// <summary>Evaluates <paramref name="instanceJson"/> against <c>#/$defs/{defName}</c>.</summary>
+        private static void Register(string uri, string fileName)
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "Schema", fileName);
+            Options.SchemaRegistry.Register(new Uri(uri), JsonSchema.FromText(File.ReadAllText(path)));
+        }
+
+        /// <summary>Evaluates <paramref name="instanceJson"/> against v1 <c>#/$defs/{defName}</c>.</summary>
         public static EvaluationResults Validate(string defName, string instanceJson)
+            => ValidateAgainst(BaseUri, defName, instanceJson);
+
+        /// <summary>Evaluates <paramref name="instanceJson"/> against v2 (alpha) <c>#/$defs/{defName}</c>.</summary>
+        public static EvaluationResults ValidateV2(string defName, string instanceJson)
+            => ValidateAgainst(BaseUriV2, defName, instanceJson);
+
+        private static EvaluationResults ValidateAgainst(string baseUri, string defName, string instanceJson)
         {
             var refSchema = new JsonSchemaBuilder()
-                .Ref($"{BaseUri}#/$defs/{defName}")
+                .Ref($"{baseUri}#/$defs/{defName}")
                 .Build();
             var node = JsonNode.Parse(instanceJson);
             return refSchema.Evaluate(node, Options);
         }
 
-        /// <summary>Asserts that the instance validates against the named schema definition.</summary>
+        /// <summary>Asserts that the instance validates against the named v1 schema definition.</summary>
         public static void AssertValid(string defName, string instanceJson)
         {
             var result = Validate(defName, instanceJson);
-            Assert.True(result.IsValid, $"Instance is not valid against {defName}:\n{instanceJson}\n{Describe(result)}");
+            Assert.True(result.IsValid, $"Instance is not valid against v1 {defName}:\n{instanceJson}\n{Describe(result)}");
+        }
+
+        /// <summary>Asserts that the instance validates against the named v2 (alpha) schema definition.</summary>
+        public static void AssertValidV2(string defName, string instanceJson)
+        {
+            var result = ValidateV2(defName, instanceJson);
+            Assert.True(result.IsValid, $"Instance is not valid against v2 {defName}:\n{instanceJson}\n{Describe(result)}");
         }
 
         private static string Describe(EvaluationResults result)

--- a/tests/Andy.Acp.Tests/Schema/acp-v2-schema.json
+++ b/tests/Andy.Acp.Tests/Schema/acp-v2-schema.json
@@ -1,0 +1,5788 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agent Client Protocol",
+  "anyOf": [
+    {
+      "title": "Agent",
+      "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+      "type": "object",
+      "properties": {
+        "jsonrpc": {
+          "type": "string",
+          "enum": ["2.0"]
+        }
+      },
+      "required": ["jsonrpc"],
+      "anyOf": [
+        {
+          "title": "Request",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AgentRequest"
+            }
+          ]
+        },
+        {
+          "title": "Response",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AgentResponse"
+            }
+          ]
+        },
+        {
+          "title": "Notification",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AgentNotification"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Client",
+      "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+      "type": "object",
+      "properties": {
+        "jsonrpc": {
+          "type": "string",
+          "enum": ["2.0"]
+        }
+      },
+      "required": ["jsonrpc"],
+      "anyOf": [
+        {
+          "title": "Request",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ClientRequest"
+            }
+          ]
+        },
+        {
+          "title": "Response",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ClientResponse"
+            }
+          ]
+        },
+        {
+          "title": "Notification",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ClientNotification"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "AgentBatchCall",
+      "description": "A non-empty JSON-RPC 2.0 batch message.",
+      "type": "array",
+      "items": {
+        "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+        "type": "object",
+        "properties": {
+          "jsonrpc": {
+            "type": "string",
+            "enum": ["2.0"]
+          }
+        },
+        "required": ["jsonrpc"],
+        "anyOf": [
+          {
+            "title": "Request",
+            "allOf": [
+              {
+                "$ref": "#/$defs/AgentRequest"
+              }
+            ]
+          },
+          {
+            "title": "Notification",
+            "allOf": [
+              {
+                "$ref": "#/$defs/AgentNotification"
+              }
+            ]
+          },
+          {
+            "title": "ProtocolLevelNotification",
+            "allOf": [
+              {
+                "$ref": "#/$defs/ProtocolLevelNotification"
+              }
+            ]
+          }
+        ]
+      },
+      "minItems": 1
+    },
+    {
+      "title": "AgentBatchResponse",
+      "description": "A non-empty JSON-RPC 2.0 batch message.",
+      "type": "array",
+      "items": {
+        "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+        "type": "object",
+        "properties": {
+          "jsonrpc": {
+            "type": "string",
+            "enum": ["2.0"]
+          }
+        },
+        "required": ["jsonrpc"],
+        "anyOf": [
+          {
+            "title": "Result",
+            "description": "A successful JSON-RPC response.",
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "The id of the request this response answers.",
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/RequestId"
+                  }
+                ]
+              },
+              "result": {
+                "description": "Method-specific response data.",
+                "anyOf": [
+                  {
+                    "title": "InitializeResponse",
+                    "description": "Successful result returned for a `initialize` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/InitializeResponse"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "LoginAuthResponse",
+                    "description": "Successful result returned for an `auth/login` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/LoginAuthResponse"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "LogoutAuthResponse",
+                    "description": "Successful result returned for an `auth/logout` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/LogoutAuthResponse"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "NewSessionResponse",
+                    "description": "Successful result returned for a `session/new` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/NewSessionResponse"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "ListSessionsResponse",
+                    "description": "Successful result returned for a `session/list` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/ListSessionsResponse"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "DeleteSessionResponse",
+                    "description": "Successful result returned for a `session/delete` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/DeleteSessionResponse"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "ResumeSessionResponse",
+                    "description": "Successful result returned for a `session/resume` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/ResumeSessionResponse"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "CloseSessionResponse",
+                    "description": "Successful result returned for a `session/close` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/CloseSessionResponse"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "SetSessionConfigOptionResponse",
+                    "description": "Successful result returned for a `session/set_config_option` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/SetSessionConfigOptionResponse"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "PromptResponse",
+                    "description": "Successful result returned for a `session/prompt` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/PromptResponse"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "ExtMethodResponse",
+                    "description": "Successful result returned by an extension method outside the core ACP method set.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/ExtResponse"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "required": ["id", "result"]
+          },
+          {
+            "title": "Error",
+            "description": "A failed JSON-RPC response.",
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "The id of the request this response answers.",
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/RequestId"
+                  }
+                ]
+              },
+              "error": {
+                "description": "Method-specific error data.",
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/Error"
+                  }
+                ]
+              }
+            },
+            "required": ["id", "error"]
+          }
+        ],
+        "x-docs-ignore": true
+      },
+      "minItems": 1
+    },
+    {
+      "title": "ClientBatchCall",
+      "description": "A non-empty JSON-RPC 2.0 batch message.",
+      "type": "array",
+      "items": {
+        "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+        "type": "object",
+        "properties": {
+          "jsonrpc": {
+            "type": "string",
+            "enum": ["2.0"]
+          }
+        },
+        "required": ["jsonrpc"],
+        "anyOf": [
+          {
+            "title": "Request",
+            "allOf": [
+              {
+                "$ref": "#/$defs/ClientRequest"
+              }
+            ]
+          },
+          {
+            "title": "Notification",
+            "allOf": [
+              {
+                "$ref": "#/$defs/ClientNotification"
+              }
+            ]
+          },
+          {
+            "title": "ProtocolLevelNotification",
+            "allOf": [
+              {
+                "$ref": "#/$defs/ProtocolLevelNotification"
+              }
+            ]
+          }
+        ]
+      },
+      "minItems": 1
+    },
+    {
+      "title": "ClientBatchResponse",
+      "description": "A non-empty JSON-RPC 2.0 batch message.",
+      "type": "array",
+      "items": {
+        "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+        "type": "object",
+        "properties": {
+          "jsonrpc": {
+            "type": "string",
+            "enum": ["2.0"]
+          }
+        },
+        "required": ["jsonrpc"],
+        "anyOf": [
+          {
+            "title": "Result",
+            "description": "A successful JSON-RPC response.",
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "The id of the request this response answers.",
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/RequestId"
+                  }
+                ]
+              },
+              "result": {
+                "description": "Method-specific response data.",
+                "anyOf": [
+                  {
+                    "title": "RequestPermissionResponse",
+                    "description": "Successful result returned for a `session/request_permission` request.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/RequestPermissionResponse"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "ExtMethodResponse",
+                    "description": "Successful result returned by an extension method outside the core ACP method set.",
+                    "allOf": [
+                      {
+                        "$ref": "#/$defs/ExtResponse"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "required": ["id", "result"]
+          },
+          {
+            "title": "Error",
+            "description": "A failed JSON-RPC response.",
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "The id of the request this response answers.",
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/RequestId"
+                  }
+                ]
+              },
+              "error": {
+                "description": "Method-specific error data.",
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/Error"
+                  }
+                ]
+              }
+            },
+            "required": ["id", "error"]
+          }
+        ],
+        "x-docs-ignore": true
+      },
+      "minItems": 1
+    },
+    {
+      "title": "ProtocolLevel",
+      "description": "A message (request, response, or notification) with `\"jsonrpc\": \"2.0\"` specified as\n[required by JSON-RPC 2.0 Specification][1].\n\n[1]: https://www.jsonrpc.org/specification#compatibility",
+      "type": "object",
+      "properties": {
+        "jsonrpc": {
+          "type": "string",
+          "enum": ["2.0"]
+        },
+        "method": {
+          "description": "The notification method name.",
+          "type": "string"
+        },
+        "params": {
+          "description": "Method-specific notification parameters.",
+          "anyOf": [
+            {
+              "description": "General protocol-level notifications that all sides are expected to\nimplement.\n\nNotifications whose methods start with '$/' are messages which\nare protocol implementation dependent and might not be implementable in all\nclients or agents. For example if the implementation uses a single threaded\nsynchronous programming language then there is little it can do to react to\na `$/cancel_request` notification. If an agent or client receives\nnotifications starting with '$/' it is free to ignore the notification.\n\nNotifications do not expect a response.",
+              "anyOf": [
+                {
+                  "title": "CancelRequestNotification",
+                  "description": "Cancels an ongoing request.\n\nThis is a notification sent by the side that sent a request to cancel that request.\n\nUpon receiving this notification, the receiver:\n\n1. MAY cancel the corresponding request activity and all nested activities\n2. MAY send any pending notifications.\n3. MUST send one of these responses for the original request:\n  - Valid response with appropriate data (partial results or cancellation marker)\n  - Error response with code `-32800` (Cancelled)\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/v2/cancellation)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/CancelRequestNotification"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": ["jsonrpc", "method"],
+      "x-docs-ignore": true
+    }
+  ],
+  "$defs": {
+    "AgentRequest": {
+      "description": "A JSON-RPC request object.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The request id used to correlate the matching response.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/RequestId"
+            }
+          ]
+        },
+        "method": {
+          "description": "The method name to invoke.",
+          "type": "string"
+        },
+        "params": {
+          "description": "Method-specific request parameters.",
+          "anyOf": [
+            {
+              "description": "All possible requests that an agent can send to a client.\n\nThis enum is used internally for routing RPC requests. You typically won't need\nto use this directly.\n\nThis enum encompasses all method calls from agent to client.",
+              "anyOf": [
+                {
+                  "title": "RequestPermissionRequest",
+                  "description": "Requests permission from the user for an operation.\n\nCalled by the agent when it needs user authorization before executing\na potentially sensitive operation. The client should present the options\nto the user and return their decision.\n\nIf the client cancels active session work via `session/cancel`, it MUST\nrespond to this request with `RequestPermissionOutcome::Cancelled`.\n\nSee protocol docs: [Requesting Permission](https://agentclientprotocol.com/protocol/v2/tool-calls#requesting-permission)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/RequestPermissionRequest"
+                    }
+                  ]
+                },
+                {
+                  "title": "ExtMethodRequest",
+                  "description": "Handles extension method requests from the agent.\n\nAllows the Agent to send an arbitrary request that is not part of the ACP spec.\nExtension methods provide a way to add custom functionality while maintaining\nprotocol compatibility.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/ExtRequest"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": ["id", "method"],
+      "x-docs-ignore": true
+    },
+    "RequestId": {
+      "description": "JSON RPC Request Id\n\nAn identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null \\[1\\] and Numbers SHOULD NOT contain fractional parts \\[2\\]\n\nThe Server MUST reply with the same value in the Response object if included. This member is used to correlate the context between the two objects.\n\n\\[1\\] The use of Null as a value for the id member in a Request object is discouraged, because this specification uses a value of Null for Responses with an unknown id. Also, because JSON-RPC 1.0 uses an id value of Null for Notifications this could cause confusion in handling.\n\n\\[2\\] Fractional parts may be problematic, since many decimal fractions cannot be represented exactly as binary fractions.",
+      "anyOf": [
+        {
+          "title": "Null",
+          "description": "The JSON-RPC `null` request id.",
+          "type": "null"
+        },
+        {
+          "title": "Number",
+          "description": "A numeric JSON-RPC request id.",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "title": "Str",
+          "description": "A string JSON-RPC request id.",
+          "type": "string"
+        }
+      ]
+    },
+    "RequestPermissionRequest": {
+      "description": "Request for user permission to proceed with an operation.\n\nSent when the agent needs authorization before performing a sensitive operation.\n\nSee protocol docs: [Requesting Permission](https://agentclientprotocol.com/protocol/v2/tool-calls#requesting-permission)",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "The session ID for this request.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "title": {
+          "description": "Human-readable title for the permission prompt.\n\nThis title is specific to the permission prompt and does not update any\nsubject's displayed title.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional human-readable explanation of why permission is needed.\n\nThis text is specific to the permission prompt and does not update any\nsubject's displayed content. Omitted or `null` both mean no separate\npermission description was provided.",
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
+        },
+        "subject": {
+          "description": "Optional structured context about the operation requiring permission.\n\nOmitted or `null` both mean no structured subject was provided.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RequestPermissionSubject"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "options": {
+          "description": "Available permission options for the user to choose from.\nMust contain at least one option.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/PermissionOption"
+          },
+          "minItems": 1
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId", "title", "options"],
+      "x-side": "client",
+      "x-method": "session/request_permission"
+    },
+    "SessionId": {
+      "description": "A unique identifier for a conversation session between a client and agent.\n\nSessions maintain their own context, conversation history, and state,\nallowing multiple independent interactions with the same agent.\n\nSee protocol docs: [Session ID](https://agentclientprotocol.com/protocol/v2/session-setup#session-id)",
+      "type": "string"
+    },
+    "RequestPermissionSubject": {
+      "description": "The operation requiring permission.",
+      "anyOf": [
+        {
+          "description": "Permission is requested before executing a tool call.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "tool_call"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/ToolCallPermissionSubject"
+            }
+          ]
+        },
+        {
+          "description": "Permission is requested before running a command.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "command"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/CommandPermissionSubject"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future permission subject.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nClients that do not understand this subject type should preserve the raw\npayload when storing, replaying, proxying, or forwarding permission\nrequests, and otherwise display a generic permission prompt or decline it\naccording to policy.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Custom or future permission subject type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["type"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "tool_call"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "command"
+                  }
+                },
+                "required": ["type"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "ToolCallUpdate": {
+      "description": "Represents an upsert for a tool call that the language model has requested.\n\nTool calls are actions that the agent executes on behalf of the language model,\nsuch as reading files, executing code, or fetching data from external sources.\n\nOnly [`ToolCallUpdate::tool_call_id`] is required. Other fields have patch semantics:\nomitted fields leave the existing tool call value unchanged, `null` clears or\nunsets the value, and concrete values replace the previous value. For\ncollection fields, concrete arrays replace the previous collection, and both\n`null` and `[]` clear the collection. When a client receives a tool call ID it\nhas not seen before, omitted fields use client defaults.\n\nSee protocol docs: [Tool Calls](https://agentclientprotocol.com/protocol/v2/tool-calls)",
+      "type": "object",
+      "properties": {
+        "toolCallId": {
+          "description": "Unique identifier for this tool call within the session.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ToolCallId"
+            }
+          ]
+        },
+        "title": {
+          "description": "Human-readable title describing what the tool is doing.",
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
+        },
+        "kind": {
+          "description": "The category of tool being invoked.\nHelps clients choose appropriate icons and UI treatment.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ToolKind"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "status": {
+          "description": "Current execution status of the tool call.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ToolCallStatus"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "content": {
+          "description": "Content produced by the tool call.",
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/$defs/ToolCallContent"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "locations": {
+          "description": "File locations affected by this tool call.\nEnables \"follow-along\" features in clients.",
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/$defs/ToolCallLocation"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "rawInput": {
+          "description": "Raw input parameters sent to the tool.",
+          "x-deserialize-default-on-error": true
+        },
+        "rawOutput": {
+          "description": "Raw output returned by the tool.",
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Omitted means no metadata update; `null` is an\nexplicit clear signal. Implementations MUST NOT make assumptions about values at these keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["toolCallId"]
+    },
+    "ToolCallId": {
+      "description": "Unique identifier for a tool call within a session.",
+      "type": "string"
+    },
+    "ToolKind": {
+      "description": "Categories of tools that can be invoked.\n\nTool kinds help clients choose appropriate icons and optimize how they\ndisplay tool execution progress.\n\nSee protocol docs: [Creating](https://agentclientprotocol.com/protocol/v2/tool-calls#creating)",
+      "anyOf": [
+        {
+          "description": "Reading files or data.",
+          "type": "string",
+          "const": "read"
+        },
+        {
+          "description": "Modifying files or content.",
+          "type": "string",
+          "const": "edit"
+        },
+        {
+          "description": "Removing files or data.",
+          "type": "string",
+          "const": "delete"
+        },
+        {
+          "description": "Moving or renaming files.",
+          "type": "string",
+          "const": "move"
+        },
+        {
+          "description": "Searching for information.",
+          "type": "string",
+          "const": "search"
+        },
+        {
+          "description": "Running commands or code.",
+          "type": "string",
+          "const": "execute"
+        },
+        {
+          "description": "Internal reasoning or planning.",
+          "type": "string",
+          "const": "think"
+        },
+        {
+          "description": "Retrieving external data.",
+          "type": "string",
+          "const": "fetch"
+        },
+        {
+          "description": "Switching the current session mode.",
+          "type": "string",
+          "const": "switch_mode"
+        },
+        {
+          "description": "Other tool types (default).",
+          "type": "string",
+          "const": "other"
+        },
+        {
+          "title": "unknown",
+          "description": "Custom or future tool kind.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "string"
+        }
+      ]
+    },
+    "ToolCallStatus": {
+      "description": "Execution status of a tool call.\n\nTool calls progress through different statuses during their lifecycle.\n\nSee protocol docs: [Status](https://agentclientprotocol.com/protocol/v2/tool-calls#status)",
+      "anyOf": [
+        {
+          "description": "The tool call hasn't started running yet because the input is either\nstreaming or we're awaiting approval.",
+          "type": "string",
+          "const": "pending"
+        },
+        {
+          "description": "The tool call is currently running.",
+          "type": "string",
+          "const": "in_progress"
+        },
+        {
+          "description": "The tool call completed successfully.",
+          "type": "string",
+          "const": "completed"
+        },
+        {
+          "description": "The tool call failed with an error.",
+          "type": "string",
+          "const": "failed"
+        },
+        {
+          "description": "The tool call was cancelled before it completed.",
+          "type": "string",
+          "const": "cancelled"
+        },
+        {
+          "title": "other",
+          "description": "Custom or future tool call status.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "string"
+        }
+      ]
+    },
+    "ToolCallContent": {
+      "description": "Content produced by a tool call.\n\nTool calls can produce different types of content including standard\ncontent blocks (text, images), file diffs, or display-only terminals.\n\nSee protocol docs: [Content](https://agentclientprotocol.com/protocol/v2/tool-calls#content)",
+      "anyOf": [
+        {
+          "description": "Standard content block (text, images, resources).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "content"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/Content"
+            }
+          ]
+        },
+        {
+          "description": "File modification shown as a diff.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "diff"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/Diff"
+            }
+          ]
+        },
+        {
+          "description": "A display-only reference to an agent-owned terminal.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "terminal"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/Terminal"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future tool call content.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nReceivers that do not understand this content type should preserve the\nraw payload when storing, replaying, proxying, or forwarding tool call\noutput, and otherwise ignore it or display it generically.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Custom or future tool call content type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["type"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "content"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "diff"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "terminal"
+                  }
+                },
+                "required": ["type"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "ContentBlock": {
+      "description": "Content blocks represent displayable information in the Agent Client Protocol.\n\nThey provide a structured way to handle various types of user-facing content—whether\nit's text from language models, images for analysis, or embedded resources for context.\n\nContent blocks appear in:\n- User prompts sent via `session/prompt`\n- Language model output reported through `session/update` notifications as\n  message updates or streamed chunks\n- Progress updates and results from tool calls\n\nThis structure is compatible with the Model Context Protocol (MCP), enabling\nagents to seamlessly forward content from MCP tool outputs without transformation.\n\nSee protocol docs: [Content](https://agentclientprotocol.com/protocol/v2/content)",
+      "anyOf": [
+        {
+          "description": "Text content. May be plain text or formatted with Markdown.\n\nAll agents MUST support text content blocks in prompts.\nClients SHOULD render this text as Markdown.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "text"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/TextContent"
+            }
+          ]
+        },
+        {
+          "description": "Images for visual context or analysis.\n\nRequires the `image` prompt capability when included in prompts.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "image"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/ImageContent"
+            }
+          ]
+        },
+        {
+          "description": "Audio data for transcription or analysis.\n\nRequires the `audio` prompt capability when included in prompts.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "audio"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/AudioContent"
+            }
+          ]
+        },
+        {
+          "description": "References to resources that the agent can access.\n\nAll agents MUST support resource links in prompts.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "resource_link"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/ResourceLink"
+            }
+          ]
+        },
+        {
+          "description": "Complete resource contents embedded directly in the message.\n\nPreferred for including context as it avoids extra round-trips.\n\nRequires the `embeddedContext` prompt capability when included in prompts.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "resource"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/EmbeddedResource"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future content block.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nReceivers that do not understand this content block type should preserve\nthe raw payload when storing, replaying, proxying, or forwarding content,\nand otherwise ignore it or display it generically.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Custom or future content block type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["type"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "text"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "image"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "audio"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "resource_link"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "resource"
+                  }
+                },
+                "required": ["type"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "Annotations": {
+      "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+      "type": "object",
+      "properties": {
+        "audience": {
+          "description": "Intended recipients for this content, such as the user or assistant.",
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/$defs/Role"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "lastModified": {
+          "description": "Timestamp indicating when the underlying resource was last modified.\n\nMust be an RFC 3339 formatted string (e.g., \"2025-01-12T15:00:58Z\").",
+          "type": ["string", "null"],
+          "format": "date-time",
+          "x-deserialize-default-on-error": true
+        },
+        "priority": {
+          "description": "Relative importance of this content when clients choose what to surface.",
+          "type": ["number", "null"],
+          "format": "double",
+          "minimum": 0,
+          "maximum": 1,
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "Role": {
+      "description": "The sender or recipient of messages and data in a conversation.",
+      "anyOf": [
+        {
+          "description": "The assistant side of a conversation.",
+          "type": "string",
+          "const": "assistant"
+        },
+        {
+          "description": "The user side of a conversation.",
+          "type": "string",
+          "const": "user"
+        },
+        {
+          "title": "other",
+          "description": "Custom or future role.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "string"
+        }
+      ]
+    },
+    "TextContent": {
+      "description": "Text provided to or from an LLM.",
+      "type": "object",
+      "properties": {
+        "text": {
+          "description": "Text payload carried by this content block.",
+          "type": "string"
+        },
+        "annotations": {
+          "description": "Optional annotations that help clients decide how to display or route this content.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Annotations"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["text"]
+    },
+    "MediaType": {
+      "description": "An Internet media type identifying the format of protocol content.",
+      "type": "string"
+    },
+    "ImageContent": {
+      "description": "An image provided to or from an LLM.",
+      "type": "object",
+      "properties": {
+        "data": {
+          "description": "Base64-encoded media payload.",
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "mimeType": {
+          "description": "MIME type describing the encoded media payload.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/MediaType"
+            }
+          ]
+        },
+        "uri": {
+          "description": "URI associated with this resource or media payload.",
+          "type": ["string", "null"],
+          "format": "uri",
+          "x-deserialize-default-on-error": true
+        },
+        "annotations": {
+          "description": "Optional annotations that help clients decide how to display or route this content.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Annotations"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["data", "mimeType"]
+    },
+    "AudioContent": {
+      "description": "Audio provided to or from an LLM.",
+      "type": "object",
+      "properties": {
+        "data": {
+          "description": "Base64-encoded media payload.",
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "mimeType": {
+          "description": "MIME type describing the encoded media payload.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/MediaType"
+            }
+          ]
+        },
+        "annotations": {
+          "description": "Optional annotations that help clients decide how to display or route this content.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Annotations"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["data", "mimeType"]
+    },
+    "Icon": {
+      "description": "An optionally-sized icon that can be displayed in a user interface.",
+      "type": "object",
+      "properties": {
+        "src": {
+          "description": "A standard URI pointing to an icon resource.",
+          "type": "string",
+          "format": "uri"
+        },
+        "mimeType": {
+          "description": "Optional MIME type override if the source MIME type is missing or generic.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MediaType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "sizes": {
+          "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in `WxH` format (e.g., `\"48x48\"`, `\"96x96\"`) or\n`\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
+          "type": ["array", "null"],
+          "items": {
+            "type": "string"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "theme": {
+          "description": "Optional theme this icon is designed for.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IconTheme"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        }
+      },
+      "required": ["src"]
+    },
+    "IconTheme": {
+      "description": "Theme an icon is designed for.",
+      "anyOf": [
+        {
+          "description": "Icon designed for light backgrounds.",
+          "type": "string",
+          "const": "light"
+        },
+        {
+          "description": "Icon designed for dark backgrounds.",
+          "type": "string",
+          "const": "dark"
+        },
+        {
+          "title": "other",
+          "description": "Custom or future icon theme.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "string"
+        }
+      ]
+    },
+    "ResourceLink": {
+      "description": "A resource that the server is capable of reading, included in a prompt or tool call result.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Human-readable name shown for this protocol object.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI associated with this resource or media payload.",
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "description": "Optional display title for end-user UI.",
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
+        },
+        "description": {
+          "description": "Optional human-readable details shown with this protocol object.",
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.",
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "mimeType": {
+          "description": "MIME type describing the encoded media payload.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MediaType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "size": {
+          "description": "Optional size of the linked resource in bytes, if known.",
+          "type": ["integer", "null"],
+          "format": "int64",
+          "x-deserialize-default-on-error": true
+        },
+        "annotations": {
+          "description": "Optional annotations that help clients decide how to display or route this content.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Annotations"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["name", "uri"]
+    },
+    "EmbeddedResourceResource": {
+      "description": "Resource content that can be embedded in a message.",
+      "anyOf": [
+        {
+          "title": "TextResourceContents",
+          "description": "Text resource contents embedded directly in the message.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/TextResourceContents"
+            }
+          ]
+        },
+        {
+          "title": "BlobResourceContents",
+          "description": "Binary resource contents embedded directly in the message.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/BlobResourceContents"
+            }
+          ]
+        }
+      ]
+    },
+    "TextResourceContents": {
+      "description": "Text-based resource contents.",
+      "type": "object",
+      "properties": {
+        "text": {
+          "description": "Text payload carried by this content block.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "URI associated with this resource or media payload.",
+          "type": "string",
+          "format": "uri"
+        },
+        "mimeType": {
+          "description": "MIME type describing the encoded media payload.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MediaType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["text", "uri"]
+    },
+    "BlobResourceContents": {
+      "description": "Binary resource contents.",
+      "type": "object",
+      "properties": {
+        "blob": {
+          "description": "Base64-encoded bytes for a binary resource payload.",
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "uri": {
+          "description": "URI associated with this resource or media payload.",
+          "type": "string",
+          "format": "uri"
+        },
+        "mimeType": {
+          "description": "MIME type describing the encoded media payload.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MediaType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["blob", "uri"]
+    },
+    "EmbeddedResource": {
+      "description": "The contents of a resource, embedded into a prompt or tool call result.",
+      "type": "object",
+      "properties": {
+        "resource": {
+          "description": "Embedded resource payload, either text or binary data.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/EmbeddedResourceResource"
+            }
+          ]
+        },
+        "annotations": {
+          "description": "Optional annotations that help clients decide how to display or route this content.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Annotations"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["resource"]
+    },
+    "Content": {
+      "description": "Standard content block (text, images, resources).",
+      "type": "object",
+      "properties": {
+        "content": {
+          "description": "The actual content block.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ContentBlock"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["content"]
+    },
+    "DiffChange": {
+      "description": "One file-level change described by a [`Diff`].\n\nStructured change metadata lets clients identify affected files and\noperations without parsing the text patch.",
+      "type": "object",
+      "properties": {
+        "fileType": {
+          "description": "File content kind.\n\nOmitted or `null` means the content kind is unknown.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DiffFileType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "mimeType": {
+          "description": "MIME type of the file contents.\n\nOmitted or `null` means the MIME type is unknown.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MediaType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "anyOf": [
+        {
+          "description": "A file was added.",
+          "type": "object",
+          "properties": {
+            "operation": {
+              "type": "string",
+              "const": "add"
+            }
+          },
+          "required": ["operation"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/DiffPathChange"
+            }
+          ]
+        },
+        {
+          "description": "A file was deleted.",
+          "type": "object",
+          "properties": {
+            "operation": {
+              "type": "string",
+              "const": "delete"
+            }
+          },
+          "required": ["operation"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/DiffPathChange"
+            }
+          ]
+        },
+        {
+          "description": "A file was modified in place.",
+          "type": "object",
+          "properties": {
+            "operation": {
+              "type": "string",
+              "const": "modify"
+            }
+          },
+          "required": ["operation"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/DiffPathChange"
+            }
+          ]
+        },
+        {
+          "description": "A file was moved or renamed.",
+          "type": "object",
+          "properties": {
+            "operation": {
+              "type": "string",
+              "const": "move"
+            }
+          },
+          "required": ["operation"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/DiffPathPairChange"
+            }
+          ]
+        },
+        {
+          "description": "A file was copied.",
+          "type": "object",
+          "properties": {
+            "operation": {
+              "type": "string",
+              "const": "copy"
+            }
+          },
+          "required": ["operation"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/DiffPathPairChange"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future file operation.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "object",
+          "properties": {
+            "operation": {
+              "description": "Custom or future file operation.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["operation"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "operation": {
+                    "type": "string",
+                    "const": "add"
+                  }
+                },
+                "required": ["operation"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "operation": {
+                    "type": "string",
+                    "const": "delete"
+                  }
+                },
+                "required": ["operation"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "operation": {
+                    "type": "string",
+                    "const": "modify"
+                  }
+                },
+                "required": ["operation"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "operation": {
+                    "type": "string",
+                    "const": "move"
+                  }
+                },
+                "required": ["operation"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "operation": {
+                    "type": "string",
+                    "const": "copy"
+                  }
+                },
+                "required": ["operation"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "DiffFileType": {
+      "description": "Kind of file content represented by a diff change.",
+      "anyOf": [
+        {
+          "description": "Text content.",
+          "type": "string",
+          "const": "text"
+        },
+        {
+          "description": "Binary or otherwise non-text content.",
+          "type": "string",
+          "const": "binary"
+        },
+        {
+          "description": "Directory entry.",
+          "type": "string",
+          "const": "directory"
+        },
+        {
+          "description": "Symbolic link.",
+          "type": "string",
+          "const": "symlink"
+        },
+        {
+          "title": "other",
+          "description": "Custom or future file type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "string"
+        }
+      ]
+    },
+    "AbsolutePath": {
+      "description": "An absolute filesystem path used by the protocol.",
+      "type": "string"
+    },
+    "DiffPathChange": {
+      "description": "Operation metadata for add, delete, and modify changes.",
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Absolute path for the operation.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AbsolutePath"
+            }
+          ]
+        }
+      },
+      "required": ["path"]
+    },
+    "DiffPathPairChange": {
+      "description": "Operation metadata for move and copy changes.",
+      "type": "object",
+      "properties": {
+        "oldPath": {
+          "description": "Absolute path before the operation.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AbsolutePath"
+            }
+          ]
+        },
+        "path": {
+          "description": "Absolute path after the operation.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AbsolutePath"
+            }
+          ]
+        }
+      },
+      "required": ["oldPath", "path"]
+    },
+    "DiffPatch": {
+      "description": "Renderable patch text and its format.",
+      "type": "object",
+      "properties": {
+        "format": {
+          "description": "Patch format. The only ACP-defined value is `git_patch`.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/DiffPatchFormat"
+            }
+          ]
+        },
+        "text": {
+          "description": "Patch text in the format named by `format`.",
+          "type": "string"
+        }
+      },
+      "required": ["format", "text"]
+    },
+    "DiffPatchFormat": {
+      "description": "Text patch format used by [`DiffPatch`].",
+      "anyOf": [
+        {
+          "description": "One or more `diff --git` sections in Git's `--patch` (`-p`) text format.\n\nPaths MUST be absolute. Surrounding commit metadata and email envelopes\nMUST NOT be included.",
+          "type": "string",
+          "const": "git_patch"
+        },
+        {
+          "title": "other",
+          "description": "Custom or future patch format.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "string"
+        }
+      ]
+    },
+    "Diff": {
+      "description": "File changes produced by a tool call.\n\n`changes` is authoritative for affected absolute paths and operations.\n`patch` optionally carries renderable text for some or all of those changes\nand MUST be consistent with `changes`. Agents SHOULD provide `patch` whenever\nfeasible. Clients MUST handle diffs where `patch` is omitted or `null`.\n\nSee protocol docs: [Content](https://agentclientprotocol.com/protocol/v2/tool-calls#content)",
+      "type": "object",
+      "properties": {
+        "changes": {
+          "description": "Structured file changes described by this diff.\n\nClients can use this field without parsing patch text to determine affected paths.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DiffChange"
+          },
+          "x-deserialize-skip-invalid-items": true
+        },
+        "patch": {
+          "description": "Renderable patch text for some or all of the structured changes.\n\nAgents SHOULD provide patch text whenever feasible. Omitted or `null`\nmeans no renderable patch text was provided.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DiffPatch"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["changes"]
+    },
+    "TerminalId": {
+      "description": "Unique identifier for an agent-owned terminal within a session.",
+      "type": "string"
+    },
+    "Terminal": {
+      "description": "A display-only reference to an agent-owned terminal.\n\nTerminal state and output are delivered separately through\n[`TerminalUpdate`] and [`TerminalOutputChunk`].",
+      "type": "object",
+      "properties": {
+        "terminalId": {
+          "description": "The ID of the terminal to display.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/TerminalId"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys. This metadata is scoped to the content reference. Omitted\nand `null` are equivalent and mean no item metadata was provided.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["terminalId"]
+    },
+    "ToolCallLocation": {
+      "description": "A file location being accessed or modified by a tool.\n\nEnables clients to implement \"follow-along\" features that track\nwhich files the agent is working with in real-time.\n\nSee protocol docs: [Following the Agent](https://agentclientprotocol.com/protocol/v2/tool-calls#following-the-agent)",
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "The absolute file path being accessed or modified.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AbsolutePath"
+            }
+          ]
+        },
+        "line": {
+          "description": "Optional line number within the file.",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["path"]
+    },
+    "ToolCallPermissionSubject": {
+      "description": "Permission request details for a tool call.",
+      "type": "object",
+      "properties": {
+        "toolCall": {
+          "description": "Details about the tool call requiring permission.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ToolCallUpdate"
+            }
+          ]
+        }
+      },
+      "required": ["toolCall"]
+    },
+    "CommandPermissionSubject": {
+      "description": "Permission request details for a command.",
+      "type": "object",
+      "properties": {
+        "command": {
+          "description": "The command that would be run if permission is granted.",
+          "type": "string"
+        },
+        "cwd": {
+          "description": "The absolute working directory for the command.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AbsolutePath"
+            }
+          ]
+        },
+        "toolCallId": {
+          "description": "The associated tool call, when known. Omitted and `null` are equivalent.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ToolCallId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "terminalId": {
+          "description": "The associated terminal, when already known. Omitted and `null` are equivalent.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TerminalId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys. Omitted and `null` are equivalent and mean no subject metadata was provided.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["command", "cwd"]
+    },
+    "PermissionOption": {
+      "description": "An option presented to the user when requesting permission.",
+      "type": "object",
+      "properties": {
+        "optionId": {
+          "description": "Unique identifier for this permission option.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/PermissionOptionId"
+            }
+          ]
+        },
+        "name": {
+          "description": "Human-readable label to display to the user.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Hint about the nature of this permission option.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/PermissionOptionKind"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["optionId", "name", "kind"]
+    },
+    "PermissionOptionId": {
+      "description": "Unique identifier for a permission option.",
+      "type": "string"
+    },
+    "PermissionOptionKind": {
+      "description": "The type of permission option being presented to the user.\n\nHelps clients choose appropriate icons and UI treatment.",
+      "anyOf": [
+        {
+          "description": "Allow this operation only this time.",
+          "type": "string",
+          "const": "allow_once"
+        },
+        {
+          "description": "Allow this operation and remember the choice.",
+          "type": "string",
+          "const": "allow_always"
+        },
+        {
+          "description": "Reject this operation only this time.",
+          "type": "string",
+          "const": "reject_once"
+        },
+        {
+          "description": "Reject this operation and remember the choice.",
+          "type": "string",
+          "const": "reject_always"
+        },
+        {
+          "title": "other",
+          "description": "Custom or future permission option kind.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "string"
+        }
+      ]
+    },
+    "ExtRequest": {
+      "description": "Allows for sending an arbitrary request that is not part of the ACP spec.\nExtension methods provide a way to add custom functionality while maintaining\nprotocol compatibility.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)"
+    },
+    "AgentResponse": {
+      "description": "A JSON-RPC response object.",
+      "anyOf": [
+        {
+          "title": "Result",
+          "description": "A successful JSON-RPC response.",
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "The id of the request this response answers.",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/RequestId"
+                }
+              ]
+            },
+            "result": {
+              "description": "Method-specific response data.",
+              "anyOf": [
+                {
+                  "title": "InitializeResponse",
+                  "description": "Successful result returned for a `initialize` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/InitializeResponse"
+                    }
+                  ]
+                },
+                {
+                  "title": "LoginAuthResponse",
+                  "description": "Successful result returned for an `auth/login` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/LoginAuthResponse"
+                    }
+                  ]
+                },
+                {
+                  "title": "LogoutAuthResponse",
+                  "description": "Successful result returned for an `auth/logout` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/LogoutAuthResponse"
+                    }
+                  ]
+                },
+                {
+                  "title": "NewSessionResponse",
+                  "description": "Successful result returned for a `session/new` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/NewSessionResponse"
+                    }
+                  ]
+                },
+                {
+                  "title": "ListSessionsResponse",
+                  "description": "Successful result returned for a `session/list` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/ListSessionsResponse"
+                    }
+                  ]
+                },
+                {
+                  "title": "DeleteSessionResponse",
+                  "description": "Successful result returned for a `session/delete` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/DeleteSessionResponse"
+                    }
+                  ]
+                },
+                {
+                  "title": "ResumeSessionResponse",
+                  "description": "Successful result returned for a `session/resume` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/ResumeSessionResponse"
+                    }
+                  ]
+                },
+                {
+                  "title": "CloseSessionResponse",
+                  "description": "Successful result returned for a `session/close` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/CloseSessionResponse"
+                    }
+                  ]
+                },
+                {
+                  "title": "SetSessionConfigOptionResponse",
+                  "description": "Successful result returned for a `session/set_config_option` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/SetSessionConfigOptionResponse"
+                    }
+                  ]
+                },
+                {
+                  "title": "PromptResponse",
+                  "description": "Successful result returned for a `session/prompt` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/PromptResponse"
+                    }
+                  ]
+                },
+                {
+                  "title": "ExtMethodResponse",
+                  "description": "Successful result returned by an extension method outside the core ACP method set.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/ExtResponse"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "required": ["id", "result"]
+        },
+        {
+          "title": "Error",
+          "description": "A failed JSON-RPC response.",
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "The id of the request this response answers.",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/RequestId"
+                }
+              ]
+            },
+            "error": {
+              "description": "Method-specific error data.",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Error"
+                }
+              ]
+            }
+          },
+          "required": ["id", "error"]
+        }
+      ],
+      "x-docs-ignore": true
+    },
+    "InitializeResponse": {
+      "description": "Response to the `initialize` method.\n\nContains the negotiated protocol version and agent capabilities.\n\nSee protocol docs: [Initialization](https://agentclientprotocol.com/protocol/v2/initialization)",
+      "type": "object",
+      "properties": {
+        "protocolVersion": {
+          "description": "The protocol version the client specified if supported by the agent,\nor the latest protocol version supported by the agent.\n\nThe client should disconnect, if it doesn't support this version.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ProtocolVersion"
+            }
+          ]
+        },
+        "info": {
+          "description": "Information about the implementation sending this initialize response.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/Implementation"
+            }
+          ]
+        },
+        "capabilities": {
+          "description": "Capabilities supported by the agent.",
+          "x-deserialize-default-on-error": true,
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/$defs/AgentCapabilities"
+            }
+          ]
+        },
+        "authMethods": {
+          "description": "Authentication methods supported by the agent.\n\nOptional. Omitted or empty means the agent does not advertise the\nauthentication method surface. Supplying one or more valid methods means\nthe agent MUST support both `auth/login` and `auth/logout`.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AuthMethod"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["protocolVersion", "info"],
+      "x-side": "agent",
+      "x-method": "initialize"
+    },
+    "ProtocolVersion": {
+      "description": "Protocol version identifier.\n\nThis version is only bumped for breaking changes.\nNon-breaking changes should be introduced via capabilities.",
+      "type": "integer",
+      "format": "uint16",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "Implementation": {
+      "description": "Metadata about the implementation of the client or agent.\nDescribes the name and version of an ACP implementation, with an optional\ntitle for UI representation.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Intended for programmatic or logical use, but can be used as a display\nname fallback if title isn’t present.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable\nand easily understood.\n\nIf not provided, the name should be used for display.",
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
+        },
+        "version": {
+          "description": "Version of the implementation. Can be displayed to the user or used\nfor debugging or metrics purposes. (e.g. \"1.0.0\").",
+          "type": "string"
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["name", "version"]
+    },
+    "AgentCapabilities": {
+      "description": "Capabilities supported by the agent.\n\nAdvertised during initialization to inform the client about\navailable features and content types.\n\nSee protocol docs: [Agent Capabilities](https://agentclientprotocol.com/protocol/v2/initialization#agent-capabilities)",
+      "type": "object",
+      "properties": {
+        "session": {
+          "description": "Session capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not support the\n`session/*` method surface. Supplying `{}` means the agent supports the\nbaseline session methods: `session/new`, `session/prompt`,\n`session/cancel`, and `session/update`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "auth": {
+          "description": "Authentication-related extension capabilities supported by the agent.\n\nOptional. Omitted or `null` both mean the agent does not advertise any\nauthentication-related extensions. This field does not advertise support\nfor `auth/login` or `auth/logout`; those methods are advertised by a\nnon-empty `authMethods` list in the `initialize` response.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AgentAuthCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "SessionCapabilities": {
+      "description": "Session capabilities supported by the agent.\n\nSupplying `{}` means the agent supports the baseline session methods:\n`session/new`, `session/list`, `session/resume`, `session/close`,\n`session/prompt`, `session/cancel`, and `session/update`.\n\nAgents that support sessions **MAY** support additional session methods,\nprompt content types, and MCP transports by specifying additional\ncapabilities.\n\nSee protocol docs: [Session Capabilities](https://agentclientprotocol.com/protocol/v2/initialization#session-capabilities)",
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "description": "Prompt capabilities supported by the agent in `session/prompt` requests.\n\nOptional. Omitted or `null` both mean the agent does not advertise any\nprompt extensions beyond the baseline text and resource-link content\nrequired by `session/prompt`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "mcp": {
+          "description": "MCP capabilities supported by the agent for session lifecycle requests.\n\nOptional. Omitted or `null` both mean the agent does not advertise MCP\nserver transport support for sessions.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "delete": {
+          "description": "Whether the agent supports `session/delete`.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports deleting sessions from `session/list`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionDeleteCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "additionalDirectories": {
+          "description": "Whether the agent supports `additionalDirectories` on supported session lifecycle requests.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports `additionalDirectories` on\nsupported session lifecycle requests.\n\nAgents may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionAdditionalDirectoriesCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "PromptCapabilities": {
+      "description": "Prompt capabilities supported by the agent in `session/prompt` requests.\n\nBaseline agent functionality requires support for [`ContentBlock::Text`]\nand [`ContentBlock::ResourceLink`] in prompt requests.\n\nOther variants must be explicitly opted in to.\nCapabilities for different types of content in prompt requests.\n\nIndicates which content types beyond the baseline (text and resource links)\nthe agent can process.\n\nSee protocol docs: [Prompt Capabilities](https://agentclientprotocol.com/protocol/v2/initialization#prompt-capabilities)",
+      "type": "object",
+      "properties": {
+        "image": {
+          "description": "Agent supports [`ContentBlock::Image`].\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports image content in prompts.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptImageCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "audio": {
+          "description": "Agent supports [`ContentBlock::Audio`].\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports audio content in prompts.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptAudioCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "embeddedContext": {
+          "description": "Agent supports embedded context in `session/prompt` requests.\n\nWhen enabled, the Client is allowed to include [`ContentBlock::Resource`]\nin prompt requests for pieces of context that are referenced in the message.\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports embedded context in prompts.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptEmbeddedContextCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "PromptImageCapabilities": {
+      "description": "Capabilities for image content in prompt requests.\n\nSupplying `{}` means the agent supports image content in prompts.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "PromptAudioCapabilities": {
+      "description": "Capabilities for audio content in prompt requests.\n\nSupplying `{}` means the agent supports audio content in prompts.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "PromptEmbeddedContextCapabilities": {
+      "description": "Capabilities for embedded context in prompt requests.\n\nSupplying `{}` means the agent supports embedded context in prompts.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "McpCapabilities": {
+      "description": "MCP capabilities supported by the agent for session lifecycle requests.",
+      "type": "object",
+      "properties": {
+        "stdio": {
+          "description": "Agent supports [`McpServer::Stdio`].\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports stdio MCP server transports.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpStdioCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "http": {
+          "description": "Agent supports [`McpServer::Http`].\n\nOptional. Omitted or `null` both mean the agent does not advertise support.\nSupplying `{}` means the agent supports HTTP MCP server transports.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpHttpCapabilities"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "McpStdioCapabilities": {
+      "description": "Capabilities for stdio MCP server transports.\n\nSupplying `{}` means the agent supports stdio MCP server transports.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "McpHttpCapabilities": {
+      "description": "Capabilities for HTTP MCP server transports.\n\nSupplying `{}` means the agent supports HTTP MCP server transports.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "SessionDeleteCapabilities": {
+      "description": "Capabilities for the `session/delete` method.\n\nSupplying `{}` means the agent supports deleting sessions from `session/list`.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "SessionAdditionalDirectoriesCapabilities": {
+      "description": "Capabilities for additional session directories support.\n\nSupplying `{}` means the agent supports the `additionalDirectories` field on\nsupported session lifecycle requests. Agents that also support\n`session/list` may return `SessionInfo.additionalDirectories` to report the\ncomplete ordered additional-root list associated with a listed session.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "AgentAuthCapabilities": {
+      "description": "Authentication-related extension capabilities supported by the agent.\n\nThis object does not advertise support for `auth/login` or `auth/logout`.\nThose methods are advertised by a non-empty `authMethods` list in the\n`initialize` response.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "AuthMethod": {
+      "description": "Describes an available authentication method.\n\nThe `type` field acts as the discriminator in the serialized JSON form.",
+      "anyOf": [
+        {
+          "description": "Agent handles authentication itself.\n\nThe `type` discriminator value is `agent`.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "agent"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/AuthMethodAgent"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future authentication method.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nClients that do not understand this method type should preserve the raw\npayload when storing, replaying, proxying, or forwarding initialization\ndata, and otherwise ignore the method or display it generically.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Custom or future authentication method type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            },
+            "methodId": {
+              "description": "Unique identifier for this authentication method.",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/AuthMethodId"
+                }
+              ]
+            },
+            "name": {
+              "description": "Human-readable name of the authentication method.",
+              "type": "string"
+            },
+            "description": {
+              "description": "Optional description providing more details about this authentication method.",
+              "type": ["string", "null"],
+              "x-deserialize-default-on-error": true
+            },
+            "_meta": {
+              "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+              "type": ["object", "null"],
+              "x-deserialize-default-on-error": true,
+              "additionalProperties": true
+            }
+          },
+          "required": ["type", "methodId", "name"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "agent"
+                  }
+                },
+                "required": ["type"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "AuthMethodId": {
+      "description": "Typed identifier used for auth method values on the wire.",
+      "type": "string"
+    },
+    "AuthMethodAgent": {
+      "description": "Agent handles authentication itself.\n\nThe `type` discriminator value is `agent`.",
+      "type": "object",
+      "properties": {
+        "methodId": {
+          "description": "Unique identifier for this authentication method.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AuthMethodId"
+            }
+          ]
+        },
+        "name": {
+          "description": "Human-readable name of the authentication method.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description providing more details about this authentication method.",
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["methodId", "name"]
+    },
+    "LoginAuthResponse": {
+      "description": "Response to the `auth/login` method.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "x-side": "agent",
+      "x-method": "auth/login"
+    },
+    "LogoutAuthResponse": {
+      "description": "Response to the `auth/logout` method.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "x-side": "agent",
+      "x-method": "auth/logout"
+    },
+    "NewSessionResponse": {
+      "description": "Response from creating a new session.\n\nSee protocol docs: [Creating a Session](https://agentclientprotocol.com/protocol/v2/session-setup#creating-a-session)",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "Unique identifier for the created session.\n\nUsed in all subsequent requests for this conversation.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "configOptions": {
+          "description": "Initial session configuration options.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SessionConfigOption"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId"],
+      "x-side": "agent",
+      "x-method": "session/new"
+    },
+    "SessionConfigOption": {
+      "description": "A session configuration option selector and its current state.",
+      "type": "object",
+      "properties": {
+        "configId": {
+          "description": "Unique identifier for the configuration option.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionConfigId"
+            }
+          ]
+        },
+        "name": {
+          "description": "Human-readable label for the option.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the Client to display to the user.",
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
+        },
+        "category": {
+          "description": "Optional semantic category for this option (UX only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionConfigOptionCategory"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["configId", "name"],
+      "anyOf": [
+        {
+          "description": "Single-value selector (dropdown).",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "select"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionConfigSelect"
+            }
+          ]
+        },
+        {
+          "description": "Boolean on/off toggle.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "boolean"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionConfigBoolean"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future session configuration option payload.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nClients that do not understand this option type should preserve the raw\npayload when storing, replaying, proxying, or forwarding configuration\ndata, and otherwise ignore the option or display it generically.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Custom or future session configuration option type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["type"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "select"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "boolean"
+                  }
+                },
+                "required": ["type"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "SessionConfigId": {
+      "description": "Unique identifier for a session configuration option.",
+      "type": "string"
+    },
+    "SessionConfigOptionCategory": {
+      "description": "Semantic category for a session configuration option.\n\nThis is intended to help Clients distinguish broadly common selectors (e.g. model selector vs\nsession mode selector vs thought/reasoning level) for UX purposes (keyboard shortcuts, icons,\nplacement). It MUST NOT be required for correctness. Clients MUST handle missing or unknown\ncategories gracefully.\n\nCategory names beginning with `_` are free for custom use, like other ACP extension methods.\nCategory names that do not begin with `_` are reserved for the ACP spec.",
+      "anyOf": [
+        {
+          "description": "Session mode selector.",
+          "type": "string",
+          "const": "mode"
+        },
+        {
+          "description": "Model selector.",
+          "type": "string",
+          "const": "model"
+        },
+        {
+          "description": "Model-related configuration parameter.",
+          "type": "string",
+          "const": "model_config"
+        },
+        {
+          "description": "Thought/reasoning level selector.",
+          "type": "string",
+          "const": "thought_level"
+        },
+        {
+          "title": "other",
+          "description": "Custom or future category.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "string"
+        }
+      ]
+    },
+    "SessionConfigValueId": {
+      "description": "Unique identifier for a session configuration option value.",
+      "type": "string"
+    },
+    "SessionConfigSelectOptions": {
+      "description": "Possible values for a session configuration option.",
+      "anyOf": [
+        {
+          "title": "Ungrouped",
+          "description": "A flat list of options with no grouping.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SessionConfigSelectOption"
+          }
+        },
+        {
+          "title": "Grouped",
+          "description": "A list of options grouped under headers.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SessionConfigSelectGroup"
+          }
+        }
+      ]
+    },
+    "SessionConfigSelectOption": {
+      "description": "A possible value for a session configuration option.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "Unique identifier for this option value.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionConfigValueId"
+            }
+          ]
+        },
+        "name": {
+          "description": "Human-readable label for this option value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for this option value.",
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["value", "name"]
+    },
+    "SessionConfigSelectGroup": {
+      "description": "A group of possible values for a session configuration option.",
+      "type": "object",
+      "properties": {
+        "groupId": {
+          "description": "Unique identifier for this group.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionConfigGroupId"
+            }
+          ]
+        },
+        "name": {
+          "description": "Human-readable label for this group.",
+          "type": "string"
+        },
+        "options": {
+          "description": "The set of option values in this group.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SessionConfigSelectOption"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["groupId", "name", "options"]
+    },
+    "SessionConfigGroupId": {
+      "description": "Unique identifier for a session configuration option value group.",
+      "type": "string"
+    },
+    "SessionConfigSelect": {
+      "description": "A single-value selector (dropdown) session configuration option payload.",
+      "type": "object",
+      "properties": {
+        "currentValue": {
+          "description": "The currently selected value.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionConfigValueId"
+            }
+          ]
+        },
+        "options": {
+          "description": "The set of selectable options.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionConfigSelectOptions"
+            }
+          ]
+        }
+      },
+      "required": ["currentValue", "options"]
+    },
+    "SessionConfigBoolean": {
+      "description": "A boolean on/off toggle session configuration option payload.",
+      "type": "object",
+      "properties": {
+        "currentValue": {
+          "description": "The current value of the boolean option.",
+          "type": "boolean"
+        }
+      },
+      "required": ["currentValue"]
+    },
+    "ListSessionsResponse": {
+      "description": "Response from listing sessions.",
+      "type": "object",
+      "properties": {
+        "sessions": {
+          "description": "Array of session information objects.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SessionInfo"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "nextCursor": {
+          "description": "Opaque cursor token. If present, pass this in the next request's cursor parameter\nto fetch the next page. If absent, there are no more results.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionListCursor"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessions"],
+      "x-side": "agent",
+      "x-method": "session/list"
+    },
+    "SessionInfo": {
+      "description": "Information about a session returned by session/list",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "Unique identifier for the session",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "cwd": {
+          "description": "The working directory for this session. Must be an absolute path.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AbsolutePath"
+            }
+          ]
+        },
+        "additionalDirectories": {
+          "description": "Additional workspace roots reported for this session. Each path must be absolute.\n\nWhen present, this is the complete ordered additional-root list reported\nby the Agent. Omitted and empty values are equivalent: the response\nreports no additional roots.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AbsolutePath"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "title": {
+          "description": "Human-readable title for the session",
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
+        },
+        "updatedAt": {
+          "description": "RFC 3339 timestamp of last activity.",
+          "type": ["string", "null"],
+          "format": "date-time",
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId", "cwd"]
+    },
+    "SessionListCursor": {
+      "description": "An opaque cursor used to paginate `session/list` results.",
+      "type": "string"
+    },
+    "DeleteSessionResponse": {
+      "description": "Response from deleting a session.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "x-side": "agent",
+      "x-method": "session/delete"
+    },
+    "ResumeSessionResponse": {
+      "description": "Response from resuming an existing session.",
+      "type": "object",
+      "properties": {
+        "configOptions": {
+          "description": "Initial session configuration options.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SessionConfigOption"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "x-side": "agent",
+      "x-method": "session/resume"
+    },
+    "CloseSessionResponse": {
+      "description": "Response from closing a session.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "x-side": "agent",
+      "x-method": "session/close"
+    },
+    "SetSessionConfigOptionResponse": {
+      "description": "Response to `session/set_config_option` method.",
+      "type": "object",
+      "properties": {
+        "configOptions": {
+          "description": "The full set of configuration options and their current values.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SessionConfigOption"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["configOptions"],
+      "x-side": "agent",
+      "x-method": "session/set_config_option"
+    },
+    "PromptResponse": {
+      "description": "Response acknowledging that a user prompt was accepted.\n\nThis response does not indicate that the agent has finished processing.\nProcessing and completion are reported through `state_update` session updates.\n\nSee protocol docs: [Prompt Accepted](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle#2-prompt-accepted)",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "x-side": "agent",
+      "x-method": "session/prompt"
+    },
+    "ExtResponse": {
+      "description": "Allows for sending an arbitrary response to an [`ExtRequest`] that is not part of the ACP spec.\nExtension methods provide a way to add custom functionality while maintaining\nprotocol compatibility.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)"
+    },
+    "Error": {
+      "description": "JSON-RPC error object.\n\nRepresents an error that occurred during method execution, following the\nJSON-RPC 2.0 error object specification with optional additional data.\n\nSee protocol docs: [JSON-RPC Error Object](https://www.jsonrpc.org/specification#error_object)",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "A number indicating the error type that occurred.\nThis must be an integer as defined in the JSON-RPC specification.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ErrorCode"
+            }
+          ]
+        },
+        "message": {
+          "description": "A string providing a short description of the error.\nThe message should be limited to a concise single sentence.",
+          "type": "string"
+        },
+        "data": {
+          "description": "Optional primitive or structured value that contains additional information about the error.\nThis may include debugging information or context-specific details.",
+          "x-deserialize-default-on-error": true
+        }
+      },
+      "required": ["code", "message"]
+    },
+    "ErrorCode": {
+      "description": "Predefined error codes for common JSON-RPC and ACP-specific errors.\n\nThese codes follow the JSON-RPC 2.0 specification for standard errors\nand use the reserved range (-32000 to -32099) for protocol-specific errors.",
+      "anyOf": [
+        {
+          "title": "Parse error",
+          "description": "**Parse error**: Invalid JSON was received by the server.\nAn error occurred on the server while parsing the JSON text.",
+          "type": "integer",
+          "format": "int32",
+          "const": -32700
+        },
+        {
+          "title": "Invalid request",
+          "description": "**Invalid request**: The JSON sent is not a valid Request object.",
+          "type": "integer",
+          "format": "int32",
+          "const": -32600
+        },
+        {
+          "title": "Method not found",
+          "description": "**Method not found**: The method does not exist or is not available.",
+          "type": "integer",
+          "format": "int32",
+          "const": -32601
+        },
+        {
+          "title": "Invalid params",
+          "description": "**Invalid params**: Invalid method parameter(s).",
+          "type": "integer",
+          "format": "int32",
+          "const": -32602
+        },
+        {
+          "title": "Internal error",
+          "description": "**Internal error**: Internal JSON-RPC error.\nReserved for implementation-defined server errors.",
+          "type": "integer",
+          "format": "int32",
+          "const": -32603
+        },
+        {
+          "title": "Request cancelled",
+          "description": "**Request cancelled**: Execution of the method was aborted either due to a cancellation request from the caller or\nbecause of resource constraints or shutdown.",
+          "type": "integer",
+          "format": "int32",
+          "const": -32800
+        },
+        {
+          "title": "Authentication required",
+          "description": "**Authentication required**: Authentication is required before this operation can be performed.",
+          "type": "integer",
+          "format": "int32",
+          "const": -32000
+        },
+        {
+          "title": "Resource not found",
+          "description": "**Resource not found**: A given resource, such as a file, was not found.",
+          "type": "integer",
+          "format": "int32",
+          "const": -32002
+        },
+        {
+          "title": "Other",
+          "description": "Other undefined error code.",
+          "type": "integer",
+          "format": "int32"
+        }
+      ]
+    },
+    "AgentNotification": {
+      "description": "A JSON-RPC notification object.",
+      "type": "object",
+      "properties": {
+        "method": {
+          "description": "The notification method name.",
+          "type": "string"
+        },
+        "params": {
+          "description": "Method-specific notification parameters.",
+          "anyOf": [
+            {
+              "description": "All possible notifications that an agent can send to a client.\n\nThis enum is used internally for routing RPC notifications. You typically won't need\nto use this directly.\n\nNotifications do not expect a response.",
+              "anyOf": [
+                {
+                  "title": "UpdateSessionNotification",
+                  "description": "Handles session update notifications from the agent.\n\nThis is a notification endpoint (no response expected) that receives\nupdates about session activity, including message updates, message chunks,\ntool calls, and execution plans.\n\nNote: Clients SHOULD continue accepting tool call updates even after\nsending a `session/cancel` notification, as the agent may send final\nupdates before reporting an idle `state_update` with the cancelled\nstop reason.\n\nSee protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle#3-agent-reports-output)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/UpdateSessionNotification"
+                    }
+                  ]
+                },
+                {
+                  "title": "ExtNotification",
+                  "description": "Handles extension notifications from the agent.\n\nAllows the Agent to send an arbitrary notification that is not part of the ACP spec.\nExtension notifications provide a way to send one-way messages for custom functionality\nwhile maintaining protocol compatibility.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/ExtNotification"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": ["method"],
+      "x-docs-ignore": true
+    },
+    "UpdateSessionNotification": {
+      "description": "Notification containing a session update from the agent.\n\nAgents can send session updates at any point while the session exists.\n\nSee protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle#3-agent-reports-output)",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "The ID of the session this update pertains to.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "update": {
+          "description": "The actual update content.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionUpdate"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId", "update"],
+      "x-side": "client",
+      "x-method": "session/update"
+    },
+    "SessionUpdate": {
+      "description": "Different types of updates that can be sent while a session exists.\n\nThese updates report messages, progress, and other session activity.\n\nSee protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle#3-agent-reports-output)",
+      "anyOf": [
+        {
+          "description": "A chunk of the user's message being streamed.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "user_message_chunk"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/ContentChunk"
+            }
+          ]
+        },
+        {
+          "description": "A user message has been created or updated.\n\nAgents can send this when they accept or replay a user message. When a\nclient receives another `user_message` update with the same `messageId`,\nfields in the new update patch the previous fields for that message.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "user_message"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/UserMessage"
+            }
+          ]
+        },
+        {
+          "description": "A chunk of the agent's response being streamed.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "agent_message_chunk"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/ContentChunk"
+            }
+          ]
+        },
+        {
+          "description": "An agent message has been created or updated.\n\nAgents can send this in addition to streamed chunks. When a client\nreceives another `agent_message` update with the same `messageId`,\nfields in the new update patch the previous fields for that message.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "agent_message"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/AgentMessage"
+            }
+          ]
+        },
+        {
+          "description": "A chunk of the agent's internal reasoning being streamed.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "agent_thought_chunk"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/ContentChunk"
+            }
+          ]
+        },
+        {
+          "description": "An agent thought or reasoning message has been created or updated.\n\nAgents can send this in addition to streamed chunks. When a client\nreceives another `agent_thought` update with the same `messageId`,\nfields in the new update patch the previous fields for that message.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "agent_thought"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/AgentThought"
+            }
+          ]
+        },
+        {
+          "description": "The state of the agent's foreground work has changed.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "state_update"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/StateUpdate"
+            }
+          ]
+        },
+        {
+          "description": "A chunk of tool-call content being streamed.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "tool_call_content_chunk"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/ToolCallContentChunk"
+            }
+          ]
+        },
+        {
+          "description": "A tool call has been created or updated.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "tool_call_update"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/ToolCallUpdate"
+            }
+          ]
+        },
+        {
+          "description": "An agent-owned terminal has been created or updated.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "terminal_update"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/TerminalUpdate"
+            }
+          ]
+        },
+        {
+          "description": "A chunk of bytes appended to an agent-owned terminal's output.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "terminal_output_chunk"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/TerminalOutputChunk"
+            }
+          ]
+        },
+        {
+          "description": "A content update for a plan identified by ID.\nSee protocol docs: [Agent Plan](https://agentclientprotocol.com/protocol/v2/agent-plan)",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "plan_update"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/PlanUpdate"
+            }
+          ]
+        },
+        {
+          "description": "Available commands are ready or have changed",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "available_commands_update"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/AvailableCommandsUpdate"
+            }
+          ]
+        },
+        {
+          "description": "Session configuration options have been updated.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "config_option_update"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/ConfigOptionUpdate"
+            }
+          ]
+        },
+        {
+          "description": "Session metadata has been updated (title, timestamps, custom metadata)",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "session_info_update"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionInfoUpdate"
+            }
+          ]
+        },
+        {
+          "description": "Context window and cost update for the session.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "type": "string",
+              "const": "usage_update"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/UsageUpdate"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future session update.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nReceivers that do not understand this update type should preserve the\nraw payload when storing, replaying, proxying, or forwarding session\nhistory, and otherwise ignore it or display it generically.",
+          "type": "object",
+          "properties": {
+            "sessionUpdate": {
+              "description": "Custom or future session update type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["sessionUpdate"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "user_message_chunk"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "user_message"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "agent_message_chunk"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "agent_message"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "agent_thought_chunk"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "agent_thought"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "state_update"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "tool_call_content_chunk"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "tool_call_update"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "terminal_update"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "terminal_output_chunk"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "plan_update"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "available_commands_update"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "config_option_update"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "session_info_update"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "sessionUpdate": {
+                    "type": "string",
+                    "const": "usage_update"
+                  }
+                },
+                "required": ["sessionUpdate"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "MessageId": {
+      "description": "Unique identifier for a message within a session.",
+      "type": "string"
+    },
+    "ContentChunk": {
+      "description": "A streamed item of message content.",
+      "type": "object",
+      "properties": {
+        "messageId": {
+          "description": "A unique identifier for the message this chunk belongs to.\n\nAll chunks belonging to the same message share the same `messageId`.\nA change in `messageId` indicates a new message has started.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/MessageId"
+            }
+          ]
+        },
+        "content": {
+          "description": "A single item of content",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ContentBlock"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys. This field is chunk-scoped.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["messageId", "content"]
+    },
+    "UserMessage": {
+      "description": "A user message upsert.\n\nOnly [`UserMessage::message_id`] is required. `content` has patch semantics:\nan omitted field leaves existing message content unchanged, `null` clears the\nvalue, and a concrete array replaces the previous value. For a new\n`messageId`, omitted fields use client defaults. `content` is replaced as a\nwhole array; send `[]` or `null` to clear it.\n\nMessage updates and chunks are applied in the order they are received. When\na `user_message` update includes `content`, that array replaces any content\npreviously accumulated for the message, including content from earlier\nchunks. Later chunks with the same `messageId` append to the current\ncontent.",
+      "type": "object",
+      "properties": {
+        "messageId": {
+          "description": "A unique identifier for the message.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/MessageId"
+            }
+          ]
+        },
+        "content": {
+          "description": "Complete replacement content for this message.",
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys. Omitted means no metadata update; `null` is an explicit clear signal.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["messageId"]
+    },
+    "AgentMessage": {
+      "description": "An agent message upsert.\n\nOnly [`AgentMessage::message_id`] is required. `content` has patch semantics:\nan omitted field leaves existing message content unchanged, `null` clears the\nvalue, and a concrete array replaces the previous value. For a new\n`messageId`, omitted fields use client defaults. `content` is replaced as a\nwhole array; send `[]` or `null` to clear it.\n\nMessage updates and chunks are applied in the order they are received. When\nan `agent_message` update includes `content`, that array replaces any\ncontent previously accumulated for the message, including content from\nearlier chunks. Later chunks with the same `messageId` append to the current\ncontent.",
+      "type": "object",
+      "properties": {
+        "messageId": {
+          "description": "A unique identifier for the message.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/MessageId"
+            }
+          ]
+        },
+        "content": {
+          "description": "Complete replacement content for this message.",
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys. Omitted means no metadata update; `null` is an explicit clear signal.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["messageId"]
+    },
+    "AgentThought": {
+      "description": "An agent thought or reasoning message upsert.\n\nOnly [`AgentThought::message_id`] is required. `content` has patch semantics:\nan omitted field leaves existing thought content unchanged, `null` clears the\nvalue, and a concrete array replaces the previous value. For a new\n`messageId`, omitted fields use client defaults. `content` is replaced as a\nwhole array; send `[]` or `null` to clear it.\n\nMessage updates and chunks are applied in the order they are received. When\nan `agent_thought` update includes `content`, that array replaces any\ncontent previously accumulated for the thought, including content from\nearlier chunks. Later chunks with the same `messageId` append to the current\ncontent.",
+      "type": "object",
+      "properties": {
+        "messageId": {
+          "description": "A unique identifier for the thought message.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/MessageId"
+            }
+          ]
+        },
+        "content": {
+          "description": "Complete replacement content for this thought message.",
+          "type": ["array", "null"],
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys. Omitted means no metadata update; `null` is an explicit clear signal.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["messageId"]
+    },
+    "RunningStateUpdate": {
+      "description": "Foreground work is in progress.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "StopReason": {
+      "description": "Reasons why an agent stops active session work.\n\nSee protocol docs: [Stop Reasons](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle#stop-reasons)",
+      "anyOf": [
+        {
+          "description": "The active work ended successfully.",
+          "type": "string",
+          "const": "end_turn"
+        },
+        {
+          "description": "The active work ended because the agent reached the maximum number of tokens.",
+          "type": "string",
+          "const": "max_tokens"
+        },
+        {
+          "description": "The active work ended because the agent reached the maximum number of\nallowed agent requests before returning idle.",
+          "type": "string",
+          "const": "max_turn_requests"
+        },
+        {
+          "description": "The active work ended because the agent refused to continue. The user\nprompt and everything that comes after it won't be included in the next\nprompt, so this should be reflected in the UI.",
+          "type": "string",
+          "const": "refusal"
+        },
+        {
+          "description": "Active session work was cancelled by the client via `session/cancel`.\n\nAgents should report this stop reason on an idle `state_update` session update\nwhen cancellation succeeds, even if cancellation causes exceptions in\nunderlying operations.",
+          "type": "string",
+          "const": "cancelled"
+        },
+        {
+          "title": "other",
+          "description": "Custom or future stop reason.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "string"
+        }
+      ]
+    },
+    "IdleStateUpdate": {
+      "description": "The agent is ready to process a new prompt.",
+      "type": "object",
+      "properties": {
+        "stopReason": {
+          "description": "Indicates why foreground work stopped.\n\nOptional. Omitted or `null` both mean the agent is not reporting a stop reason.\nAgents SHOULD include this when the idle transition ends foreground work.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StopReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "RequiresActionStateUpdate": {
+      "description": "Foreground work is blocked on user action.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "StateUpdate": {
+      "description": "The state of the agent's foreground work has changed.\n\nBackground activity can continue and emit other `session/update` notifications\nwhile `idle`. Those notifications do not change this state.",
+      "anyOf": [
+        {
+          "description": "Foreground work is in progress.",
+          "type": "object",
+          "properties": {
+            "state": {
+              "type": "string",
+              "const": "running"
+            }
+          },
+          "required": ["state"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/RunningStateUpdate"
+            }
+          ]
+        },
+        {
+          "description": "The agent is ready to process a new prompt.",
+          "type": "object",
+          "properties": {
+            "state": {
+              "type": "string",
+              "const": "idle"
+            }
+          },
+          "required": ["state"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/IdleStateUpdate"
+            }
+          ]
+        },
+        {
+          "description": "Foreground work is blocked on user action.",
+          "type": "object",
+          "properties": {
+            "state": {
+              "type": "string",
+              "const": "requires_action"
+            }
+          },
+          "required": ["state"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/RequiresActionStateUpdate"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future session state.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "object",
+          "properties": {
+            "state": {
+              "description": "Custom or future session state.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["state"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "state": {
+                    "type": "string",
+                    "const": "running"
+                  }
+                },
+                "required": ["state"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "state": {
+                    "type": "string",
+                    "const": "idle"
+                  }
+                },
+                "required": ["state"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "state": {
+                    "type": "string",
+                    "const": "requires_action"
+                  }
+                },
+                "required": ["state"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "ToolCallContentChunk": {
+      "description": "A streamed item of tool-call content.\n\nTool-call content chunks append one [`ToolCallContent`] item to the current\ncontent for the matching [`ToolCallId`]. Agents can use\n[`ToolCallUpdate::content`] when they need to replace the whole content\ncollection instead.",
+      "type": "object",
+      "properties": {
+        "toolCallId": {
+          "description": "The ID of the tool call this content belongs to.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ToolCallId"
+            }
+          ]
+        },
+        "content": {
+          "description": "A single item of content produced by the tool call.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ToolCallContent"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys. This field is chunk-scoped.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["toolCallId", "content"]
+    },
+    "TerminalOutput": {
+      "description": "An authoritative replacement snapshot of terminal output bytes.",
+      "type": "object",
+      "properties": {
+        "data": {
+          "description": "Base64-encoded replacement terminal output bytes.",
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys. This metadata is scoped to the replacement snapshot. Omitted\nand `null` are equivalent and mean no snapshot metadata was provided.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["data"]
+    },
+    "TerminalExitStatus": {
+      "description": "Exit information for an agent-owned terminal.\n\nThe presence of this object marks the terminal as exited, even when neither\nan exit code nor a signal is known.",
+      "type": "object",
+      "properties": {
+        "exitCode": {
+          "description": "Process exit code, when known. Omitted and `null` are equivalent.",
+          "type": ["integer", "null"],
+          "format": "uint32",
+          "minimum": 0,
+          "x-deserialize-default-on-error": true
+        },
+        "signal": {
+          "description": "Signal that terminated the process, when known.\n\nAgents should use the conventional platform signal name. POSIX examples\ninclude `SIGTERM`, `SIGKILL`, and `SIGINT`. Other platforms may use a\nplatform-specific name. Omitted and `null` are equivalent.",
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys. This metadata is scoped to the exit information. Omitted\nand `null` are equivalent and mean no exit metadata was provided.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "TerminalUpdate": {
+      "description": "An upsert for the stored state of an agent-owned terminal.\n\nOnly [`TerminalUpdate::terminal_id`] is required. Other fields have patch\nsemantics: omitted fields leave the stored value unchanged, `null` clears\nit, and concrete values replace it. When the terminal ID is new, omitted\nfields start unknown.",
+      "type": "object",
+      "properties": {
+        "terminalId": {
+          "description": "Unique identifier for this terminal within the session.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/TerminalId"
+            }
+          ]
+        },
+        "command": {
+          "description": "The command being run.",
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
+        },
+        "cwd": {
+          "description": "The absolute working directory of the command.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AbsolutePath"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "output": {
+          "description": "An authoritative replacement snapshot of terminal output bytes.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TerminalOutput"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "exitStatus": {
+          "description": "Exit information. A concrete object marks the terminal as exited.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TerminalExitStatus"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Omitted means no metadata update; `null` is an\nexplicit clear signal. Implementations MUST NOT make assumptions about values at these keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["terminalId"]
+    },
+    "TerminalOutputChunk": {
+      "description": "A chunk of bytes appended to an agent-owned terminal's output.",
+      "type": "object",
+      "properties": {
+        "terminalId": {
+          "description": "The terminal receiving these bytes.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/TerminalId"
+            }
+          ]
+        },
+        "data": {
+          "description": "Independently base64-encoded terminal output bytes.",
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys. This field is chunk-scoped. Omitted and `null` are\nequivalent and mean no chunk metadata was provided.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["terminalId", "data"]
+    },
+    "PlanUpdateContent": {
+      "description": "Updated content for a plan.",
+      "anyOf": [
+        {
+          "description": "Structured plan entries.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "items"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/PlanItems"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future plan update content.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nReceivers that do not understand this content type should preserve the\nraw payload when storing, replaying, proxying, or forwarding plans, and\notherwise ignore it or display it generically.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Custom or future plan update content type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            },
+            "planId": {
+              "description": "The plan ID to update.",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/PlanId"
+                }
+              ]
+            }
+          },
+          "required": ["type", "planId"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "items"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "file"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "markdown"
+                  }
+                },
+                "required": ["type"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "PlanId": {
+      "description": "Unique identifier for a plan within a session.",
+      "type": "string"
+    },
+    "PlanEntry": {
+      "description": "A single entry in the execution plan.\n\nRepresents a task or goal that the assistant intends to accomplish\nas part of fulfilling the user's request.\nSee protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/v2/agent-plan#plan-entries)",
+      "type": "object",
+      "properties": {
+        "content": {
+          "description": "Human-readable description of what this task aims to accomplish.",
+          "type": "string"
+        },
+        "priority": {
+          "description": "The relative importance of this task.\nUsed to indicate which tasks are most critical to the overall goal.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/PlanEntryPriority"
+            }
+          ]
+        },
+        "status": {
+          "description": "Current execution status of this task.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/PlanEntryStatus"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["content", "priority", "status"]
+    },
+    "PlanEntryPriority": {
+      "description": "Priority levels for plan entries.\n\nUsed to indicate the relative importance or urgency of different\ntasks in the execution plan.\nSee protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/v2/agent-plan#plan-entries)",
+      "anyOf": [
+        {
+          "description": "High priority task - critical to the overall goal.",
+          "type": "string",
+          "const": "high"
+        },
+        {
+          "description": "Medium priority task - important but not critical.",
+          "type": "string",
+          "const": "medium"
+        },
+        {
+          "description": "Low priority task - nice to have but not essential.",
+          "type": "string",
+          "const": "low"
+        },
+        {
+          "title": "other",
+          "description": "Custom or future plan entry priority.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "string"
+        }
+      ]
+    },
+    "PlanEntryStatus": {
+      "description": "Status of a plan entry in the execution flow.\n\nTracks the lifecycle of each task from planning through completion.\nSee protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/v2/agent-plan#plan-entries)",
+      "anyOf": [
+        {
+          "description": "The task has not started yet.",
+          "type": "string",
+          "const": "pending"
+        },
+        {
+          "description": "The task is currently being worked on.",
+          "type": "string",
+          "const": "in_progress"
+        },
+        {
+          "description": "The task has been successfully completed.",
+          "type": "string",
+          "const": "completed"
+        },
+        {
+          "description": "The task was cancelled before it completed.",
+          "type": "string",
+          "const": "cancelled"
+        },
+        {
+          "title": "other",
+          "description": "Custom or future plan entry status.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "string"
+        }
+      ]
+    },
+    "PlanItems": {
+      "description": "A plan represented as structured entries.",
+      "type": "object",
+      "properties": {
+        "planId": {
+          "description": "The plan ID to update.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/PlanId"
+            }
+          ]
+        },
+        "entries": {
+          "description": "The list of tasks to be accomplished.\n\nWhen updating an item-based plan, the agent must send a complete list of all entries\nwith their current status. The client replaces that plan with each update.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/PlanEntry"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["planId", "entries"]
+    },
+    "PlanUpdate": {
+      "description": "A content update for a plan identified by ID.",
+      "type": "object",
+      "properties": {
+        "plan": {
+          "description": "The updated plan content.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/PlanUpdateContent"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["plan"]
+    },
+    "AvailableCommand": {
+      "description": "Information about a command.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Command name (e.g., `create_plan`, `research_codebase`).",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the command does.",
+          "type": "string"
+        },
+        "input": {
+          "description": "Input for the command if required",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AvailableCommandInput"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["name", "description"]
+    },
+    "AvailableCommandInput": {
+      "description": "The input specification for a command.",
+      "anyOf": [
+        {
+          "description": "All text that was typed after the command name is provided as input.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "text"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/TextCommandInput"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future command input specification.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nClients that do not understand this input type should preserve the raw\npayload when storing, replaying, proxying, or forwarding command\nmetadata, and otherwise ignore the input specification or display the\ncommand without structured input.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Custom or future command input type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["type"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "text"
+                  }
+                },
+                "required": ["type"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "TextCommandInput": {
+      "description": "All text that was typed after the command name is provided as input.",
+      "type": "object",
+      "properties": {
+        "hint": {
+          "description": "A hint to display when the input hasn't been provided yet",
+          "type": "string"
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["hint"]
+    },
+    "AvailableCommandsUpdate": {
+      "description": "Available commands are ready or have changed",
+      "type": "object",
+      "properties": {
+        "availableCommands": {
+          "description": "Commands the agent can execute.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AvailableCommand"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["availableCommands"]
+    },
+    "ConfigOptionUpdate": {
+      "description": "Session configuration options have been updated.",
+      "type": "object",
+      "properties": {
+        "configOptions": {
+          "description": "The full set of configuration options and their current values.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SessionConfigOption"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["configOptions"]
+    },
+    "SessionInfoUpdate": {
+      "description": "Update to session metadata. All fields are optional to support partial updates.\n\nAgents send this notification to update session information like title or custom metadata.\nThis allows clients to display dynamic session names and track session state changes.\n\nOmitted fields leave the existing session info unchanged. `null` clears the\ncorresponding value.",
+      "type": "object",
+      "properties": {
+        "title": {
+          "description": "Human-readable title for the session. Set to null to clear.",
+          "type": ["string", "null"],
+          "x-deserialize-default-on-error": true
+        },
+        "updatedAt": {
+          "description": "RFC 3339 timestamp of last activity. Set to null to clear.",
+          "type": ["string", "null"],
+          "format": "date-time",
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Omitted means no metadata update; `null` is an\nexplicit clear signal. Implementations MUST NOT make assumptions about values at these keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "Cost": {
+      "description": "Cost information for a session.",
+      "type": "object",
+      "properties": {
+        "amount": {
+          "description": "Total cumulative cost for session.",
+          "type": "number",
+          "format": "double"
+        },
+        "currency": {
+          "description": "ISO 4217 currency code (e.g., \"USD\", \"EUR\").",
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["amount", "currency"]
+    },
+    "UsageUpdate": {
+      "description": "Context window and cost update for a session.",
+      "type": "object",
+      "properties": {
+        "used": {
+          "description": "Tokens currently in context.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        },
+        "size": {
+          "description": "Total context window size in tokens.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        },
+        "cost": {
+          "description": "Cumulative session cost (optional).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Cost"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["used", "size"]
+    },
+    "ExtNotification": {
+      "description": "Allows the Agent to send an arbitrary notification that is not part of the ACP spec.\nExtension notifications provide a way to send one-way messages for custom functionality\nwhile maintaining protocol compatibility.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)"
+    },
+    "ClientRequest": {
+      "description": "A JSON-RPC request object.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The request id used to correlate the matching response.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/RequestId"
+            }
+          ]
+        },
+        "method": {
+          "description": "The method name to invoke.",
+          "type": "string"
+        },
+        "params": {
+          "description": "Method-specific request parameters.",
+          "anyOf": [
+            {
+              "description": "All possible requests that a client can send to an agent.\n\nThis enum is used internally for routing RPC requests. You typically won't need\nto use this directly.\n\nThis enum encompasses all method calls from client to agent.",
+              "anyOf": [
+                {
+                  "title": "InitializeRequest",
+                  "description": "Establishes the connection with a client and negotiates protocol capabilities.\n\nThis method is called once at the beginning of the connection to:\n- Negotiate the protocol version to use\n- Exchange capability information between client and agent\n- Determine available authentication methods\n\nThe agent should respond with its supported protocol version and capabilities.\n\nSee protocol docs: [Initialization](https://agentclientprotocol.com/protocol/v2/initialization)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/InitializeRequest"
+                    }
+                  ]
+                },
+                {
+                  "title": "LoginAuthRequest",
+                  "description": "Authenticates the client using the specified authentication method.\n\nAgents MUST support this method when their `initialize` response advertised\nat least one valid authentication method. Clients MUST NOT call this method\nwhen `authMethods` was omitted or empty.\n\nCalled when the agent requires authentication before allowing session creation.\nThe client provides the authentication method ID that was advertised during initialization.\n\nAfter successful authentication, the client can proceed to create sessions with\n`new_session` without receiving an `auth_required` error.\n\nSee protocol docs: [Initialization](https://agentclientprotocol.com/protocol/v2/initialization)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/LoginAuthRequest"
+                    }
+                  ]
+                },
+                {
+                  "title": "LogoutAuthRequest",
+                  "description": "Logs out of the current authenticated state.\n\nAgents MUST support this method when their `initialize` response advertised\nat least one valid authentication method. Clients MUST NOT call this method\nwhen `authMethods` was omitted or empty.\n\nAfter a successful logout, authentication-gated requests require the client\nto authenticate again. There is no guarantee about the behavior of already\nrunning sessions.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/LogoutAuthRequest"
+                    }
+                  ]
+                },
+                {
+                  "title": "NewSessionRequest",
+                  "description": "Creates a new conversation session with the agent.\n\nSessions represent independent conversation contexts with their own history and state.\n\nThe agent should:\n- Create a new session context\n- Connect to any specified MCP servers\n- Return a unique session ID for future requests\n\nMay return an `auth_required` error if the agent requires authentication.\n\nSee protocol docs: [Session Setup](https://agentclientprotocol.com/protocol/v2/session-setup)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/NewSessionRequest"
+                    }
+                  ]
+                },
+                {
+                  "title": "ListSessionsRequest",
+                  "description": "Lists existing sessions known to the agent.\n\nThe agent should return metadata about sessions with optional filtering and pagination support.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/ListSessionsRequest"
+                    }
+                  ]
+                },
+                {
+                  "title": "DeleteSessionRequest",
+                  "description": "Deletes an existing session from `session/list`.\n\nThis method is only available if the agent advertises the `session.delete` capability.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/DeleteSessionRequest"
+                    }
+                  ]
+                },
+                {
+                  "title": "ResumeSessionRequest",
+                  "description": "Resumes an existing session.\n\nThe agent should resume the session context, allowing the conversation\nto continue. If `replayFrom` is set, the agent should replay\nconversation history before responding.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/ResumeSessionRequest"
+                    }
+                  ]
+                },
+                {
+                  "title": "CloseSessionRequest",
+                  "description": "Closes an active session and frees up any resources associated with it.\n\nThe agent must cancel any ongoing work (as if `session/cancel` was called)\nand then free up any resources associated with the session.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/CloseSessionRequest"
+                    }
+                  ]
+                },
+                {
+                  "title": "SetSessionConfigOptionRequest",
+                  "description": "Sets the current value for a session configuration option.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/SetSessionConfigOptionRequest"
+                    }
+                  ]
+                },
+                {
+                  "title": "PromptRequest",
+                  "description": "Processes a user prompt within a session.\n\nThis request accepts the prompt:\n- Receives user messages with optional context (files, images, etc.)\n- Returns once the prompt is accepted\n\nAfter acceptance, the Agent reports the accepted user message,\nprocessing state, output, tool calls, and completion through\n`session/update` notifications.\n\nSee protocol docs: [Prompt Lifecycle](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/PromptRequest"
+                    }
+                  ]
+                },
+                {
+                  "title": "ExtMethodRequest",
+                  "description": "Handles extension method requests from the client.\n\nExtension methods provide a way to add custom functionality while maintaining\nprotocol compatibility.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/ExtRequest"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": ["id", "method"],
+      "x-docs-ignore": true
+    },
+    "InitializeRequest": {
+      "description": "Request parameters for the initialize method.\n\nSent by the client to establish connection and negotiate capabilities.\n\nSee protocol docs: [Initialization](https://agentclientprotocol.com/protocol/v2/initialization)",
+      "type": "object",
+      "properties": {
+        "protocolVersion": {
+          "description": "The latest protocol version supported by the client.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/ProtocolVersion"
+            }
+          ]
+        },
+        "info": {
+          "description": "Information about the implementation sending this initialize request.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/Implementation"
+            }
+          ]
+        },
+        "capabilities": {
+          "description": "Capabilities supported by the client.",
+          "x-deserialize-default-on-error": true,
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/$defs/ClientCapabilities"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["protocolVersion", "info"],
+      "x-side": "agent",
+      "x-method": "initialize"
+    },
+    "ClientCapabilities": {
+      "description": "Capabilities supported by the client.\n\nAdvertised during initialization to inform the agent about\navailable features and methods.\n\nSee protocol docs: [Client Capabilities](https://agentclientprotocol.com/protocol/v2/initialization#client-capabilities)",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "LoginAuthRequest": {
+      "description": "Request parameters for the `auth/login` method.\n\nSpecifies which authentication method to use.\n\nAgents MUST support this method when their `initialize` response advertised\nat least one valid authentication method. Clients MUST NOT call this method\nwhen `authMethods` was omitted or empty.",
+      "type": "object",
+      "properties": {
+        "methodId": {
+          "description": "The ID of the authentication method to use.\nMust be one of the methods advertised in the initialize response.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AuthMethodId"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["methodId"],
+      "x-side": "agent",
+      "x-method": "auth/login"
+    },
+    "LogoutAuthRequest": {
+      "description": "Request parameters for the `auth/logout` method.\n\nTerminates the current authenticated session.\n\nAgents MUST support this method when their `initialize` response advertised\nat least one valid authentication method. Clients MUST NOT call this method\nwhen `authMethods` was omitted or empty.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "x-side": "agent",
+      "x-method": "auth/logout"
+    },
+    "NewSessionRequest": {
+      "description": "Request parameters for creating a new session.\n\nSee protocol docs: [Creating a Session](https://agentclientprotocol.com/protocol/v2/session-setup#creating-a-session)",
+      "type": "object",
+      "properties": {
+        "cwd": {
+          "description": "The working directory for this session. Must be an absolute path.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AbsolutePath"
+            }
+          ]
+        },
+        "additionalDirectories": {
+          "description": "Additional workspace roots for this session. Each path must be absolute.\n\nThese expand the session's workspace scope without changing `cwd`, which\nremains the base for relative paths. When omitted or empty, no\nadditional roots are activated for the new session.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AbsolutePath"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "mcpServers": {
+          "description": "List of MCP (Model Context Protocol) servers the agent should connect to.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/McpServer"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["cwd"],
+      "x-side": "agent",
+      "x-method": "session/new"
+    },
+    "McpServer": {
+      "description": "Configuration for connecting to an MCP (Model Context Protocol) server.\n\nMCP servers provide tools and context that the agent can use when\nprocessing prompts.\n\nSee protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/v2/session-setup#mcp-servers)",
+      "anyOf": [
+        {
+          "description": "HTTP transport configuration\n\nOnly available when the Agent capabilities include `session.mcp.http`.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "http"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/McpServerHttp"
+            }
+          ]
+        },
+        {
+          "description": "Stdio transport configuration\n\nOnly available when the Agent capabilities include `session.mcp.stdio`.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "stdio"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/McpServerStdio"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future MCP server transport configuration.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nReceivers that do not understand this transport should preserve the raw\npayload when storing, replaying, proxying, or forwarding session setup\ndata, and otherwise ignore it or reject the server configuration.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Custom or future MCP server transport type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["type"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "http"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "stdio"
+                  }
+                },
+                "required": ["type"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "HttpHeader": {
+      "description": "An HTTP header to set when making requests to the MCP server.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the HTTP header.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value to set for the HTTP header.",
+          "type": "string"
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["name", "value"]
+    },
+    "McpServerHttp": {
+      "description": "HTTP transport configuration for MCP.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Human-readable name identifying this MCP server.",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL to the MCP server.",
+          "type": "string",
+          "format": "uri"
+        },
+        "headers": {
+          "description": "HTTP headers to set when making requests to the MCP server.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/HttpHeader"
+          }
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["name", "url"]
+    },
+    "EnvVariable": {
+      "description": "An environment variable to set when launching an MCP server.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the environment variable.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value to set for the environment variable.",
+          "type": "string"
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["name", "value"]
+    },
+    "McpServerStdio": {
+      "description": "Stdio transport configuration for MCP.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Human-readable name identifying this MCP server.",
+          "type": "string"
+        },
+        "command": {
+          "description": "Absolute path to the MCP server executable.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AbsolutePath"
+            }
+          ]
+        },
+        "args": {
+          "description": "Command-line arguments to pass to the MCP server.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "description": "Environment variables to set when launching the MCP server.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EnvVariable"
+          }
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["name", "command"]
+    },
+    "ListSessionsRequest": {
+      "description": "Request parameters for listing existing sessions.",
+      "type": "object",
+      "properties": {
+        "cwd": {
+          "description": "Filter sessions by working directory. Must be an absolute path.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AbsolutePath"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cursor": {
+          "description": "Opaque cursor token from a previous response's nextCursor field for cursor-based pagination",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionListCursor"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "x-side": "agent",
+      "x-method": "session/list"
+    },
+    "DeleteSessionRequest": {
+      "description": "Request parameters for deleting an existing session from `session/list`.\n\nOnly available if the Agent supports the `session.delete` capability.",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "The ID of the session to delete.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId"],
+      "x-side": "agent",
+      "x-method": "session/delete"
+    },
+    "ResumeSessionRequest": {
+      "description": "Request parameters for resuming an existing session.\n\nResumes an existing session and optionally replays prior conversation\nhistory according to `replayFrom`.",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "The ID of the session to resume.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "cwd": {
+          "description": "The working directory for this session. Must be an absolute path.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/AbsolutePath"
+            }
+          ]
+        },
+        "additionalDirectories": {
+          "description": "Additional workspace roots to activate for this session. Each path must be absolute.\n\nWhen omitted or empty, no additional roots are activated. When non-empty,\nthis is the complete resulting additional-root list for the resumed\nsession. It may differ from any previously used or reported list as long as\nthe request `cwd` matches the session's `cwd`.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AbsolutePath"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "mcpServers": {
+          "description": "List of MCP servers to connect to for this session.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/McpServer"
+          },
+          "x-deserialize-default-on-error": true,
+          "x-deserialize-skip-invalid-items": true
+        },
+        "replayFrom": {
+          "description": "Inclusive cursor describing where conversation replay should begin.\n\nOptional. Omitted or `null` both mean the Agent should resume without\nreplaying previous conversation history. Replay cursors are inclusive:\nreplay includes the position identified by the cursor. Supplying\n`{ \"type\": \"start\" }` means the Agent should replay the whole\nconversation before responding.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReplayFrom"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "x-deserialize-default-on-error": true
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId", "cwd"],
+      "x-side": "agent",
+      "x-method": "session/resume"
+    },
+    "ReplayFrom": {
+      "description": "Inclusive cursor describing where replayed session history should begin.\n\nReplay includes the position identified by the cursor.",
+      "anyOf": [
+        {
+          "description": "Replay the whole conversation from its first replayable entry.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "start"
+            }
+          },
+          "required": ["type"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/ReplayFromStart"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future replay cursor.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nReceivers that do not understand this cursor should preserve the raw\npayload when storing, replaying, proxying, or forwarding requests, and\notherwise reject the request rather than guessing where to replay from.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Custom or future replay cursor type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            },
+            "_meta": {
+              "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+              "type": ["object", "null"],
+              "x-deserialize-default-on-error": true,
+              "additionalProperties": true
+            }
+          },
+          "required": ["type"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "start"
+                  }
+                },
+                "required": ["type"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "ReplayFromStart": {
+      "description": "Inclusive replay cursor requesting replay from the start of the conversation.",
+      "type": "object",
+      "properties": {
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      }
+    },
+    "CloseSessionRequest": {
+      "description": "Request parameters for closing an active session.\n\nThe agent **must** cancel any ongoing work related to the session (treat it\nas if `session/cancel` was called) and then free up any resources associated\nwith the session.",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "The ID of the session to close.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId"],
+      "x-side": "agent",
+      "x-method": "session/close"
+    },
+    "SetSessionConfigOptionRequest": {
+      "description": "Request parameters for setting a session configuration option.",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "The ID of the session to set the configuration option for.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "configId": {
+          "description": "The ID of the configuration option to set.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionConfigId"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId", "configId"],
+      "anyOf": [
+        {
+          "description": "A [`SessionConfigValueId`] string value (`type: \"id\"`).",
+          "type": "object",
+          "properties": {
+            "value": {
+              "description": "The value ID.",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/SessionConfigValueId"
+                }
+              ]
+            },
+            "type": {
+              "type": "string",
+              "const": "id"
+            }
+          },
+          "required": ["type", "value"]
+        },
+        {
+          "description": "A boolean value (`type: \"boolean\"`).",
+          "type": "object",
+          "properties": {
+            "value": {
+              "description": "The boolean value.",
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "const": "boolean"
+            }
+          },
+          "required": ["type", "value"]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future session configuration option value payload.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Custom or future session configuration option value type.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            },
+            "value": {
+              "description": "Raw value payload for the custom or future value type."
+            }
+          },
+          "required": ["type", "value"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "id"
+                  }
+                },
+                "required": ["type"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "boolean"
+                  }
+                },
+                "required": ["type"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ],
+      "x-side": "agent",
+      "x-method": "session/set_config_option"
+    },
+    "PromptRequest": {
+      "description": "Request parameters for sending a user prompt to the agent.\n\nContains the user's message and any additional context.\n\nSee protocol docs: [User Message](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle#1-user-message)",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "The ID of the session to send this user message to",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "prompt": {
+          "description": "The blocks of content that compose the user's message.\n\nAs a baseline, the Agent MUST support [`ContentBlock::Text`] and [`ContentBlock::ResourceLink`],\nwhile other variants are optionally enabled via [`PromptCapabilities`].\n\nThe Client MUST adapt its interface according to [`PromptCapabilities`].\n\nThe client MAY include referenced pieces of context as either\n[`ContentBlock::Resource`] or [`ContentBlock::ResourceLink`].\n\nWhen available, [`ContentBlock::Resource`] is preferred\nas it avoids extra round-trips and allows the message to include\npieces of context from sources the agent may not have access to.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          }
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId", "prompt"],
+      "x-side": "agent",
+      "x-method": "session/prompt"
+    },
+    "ClientResponse": {
+      "description": "A JSON-RPC response object.",
+      "anyOf": [
+        {
+          "title": "Result",
+          "description": "A successful JSON-RPC response.",
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "The id of the request this response answers.",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/RequestId"
+                }
+              ]
+            },
+            "result": {
+              "description": "Method-specific response data.",
+              "anyOf": [
+                {
+                  "title": "RequestPermissionResponse",
+                  "description": "Successful result returned for a `session/request_permission` request.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/RequestPermissionResponse"
+                    }
+                  ]
+                },
+                {
+                  "title": "ExtMethodResponse",
+                  "description": "Successful result returned by an extension method outside the core ACP method set.",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/ExtResponse"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "required": ["id", "result"]
+        },
+        {
+          "title": "Error",
+          "description": "A failed JSON-RPC response.",
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "The id of the request this response answers.",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/RequestId"
+                }
+              ]
+            },
+            "error": {
+              "description": "Method-specific error data.",
+              "allOf": [
+                {
+                  "$ref": "#/$defs/Error"
+                }
+              ]
+            }
+          },
+          "required": ["id", "error"]
+        }
+      ],
+      "x-docs-ignore": true
+    },
+    "RequestPermissionResponse": {
+      "description": "Response to a permission request.",
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "description": "The user's decision on the permission request.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/RequestPermissionOutcome"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["outcome"],
+      "x-side": "client",
+      "x-method": "session/request_permission"
+    },
+    "RequestPermissionOutcome": {
+      "description": "The outcome of a permission request.",
+      "anyOf": [
+        {
+          "description": "Active session work was cancelled before the user responded.\n\nWhen a client sends a `session/cancel` notification to cancel active\nsession work, it MUST respond to all pending `session/request_permission`\nrequests with this `Cancelled` outcome.\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle#cancellation)",
+          "type": "object",
+          "properties": {
+            "outcome": {
+              "type": "string",
+              "const": "cancelled"
+            }
+          },
+          "required": ["outcome"]
+        },
+        {
+          "description": "The user selected one of the provided options.",
+          "type": "object",
+          "properties": {
+            "outcome": {
+              "type": "string",
+              "const": "selected"
+            }
+          },
+          "required": ["outcome"],
+          "allOf": [
+            {
+              "$ref": "#/$defs/SelectedPermissionOutcome"
+            }
+          ]
+        },
+        {
+          "title": "other",
+          "description": "Custom or future permission outcome.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.\n\nAgents that do not understand this outcome MUST NOT treat it as approval.\nThey should preserve the raw payload when storing, replaying, proxying, or\nforwarding permission responses, and otherwise fail or decline the\npermission request according to policy.",
+          "type": "object",
+          "properties": {
+            "outcome": {
+              "description": "Custom or future permission outcome.\n\nValues beginning with `_` are reserved for implementation-specific\nextensions. Unknown values that do not begin with `_` are reserved for\nfuture ACP variants.",
+              "type": "string"
+            }
+          },
+          "required": ["outcome"],
+          "not": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "outcome": {
+                    "type": "string",
+                    "const": "cancelled"
+                  }
+                },
+                "required": ["outcome"]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "outcome": {
+                    "type": "string",
+                    "const": "selected"
+                  }
+                },
+                "required": ["outcome"]
+              }
+            ]
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "SelectedPermissionOutcome": {
+      "description": "The user selected one of the provided options.",
+      "type": "object",
+      "properties": {
+        "optionId": {
+          "description": "The ID of the option the user selected.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/PermissionOptionId"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["optionId"]
+    },
+    "ClientNotification": {
+      "description": "A JSON-RPC notification object.",
+      "type": "object",
+      "properties": {
+        "method": {
+          "description": "The notification method name.",
+          "type": "string"
+        },
+        "params": {
+          "description": "Method-specific notification parameters.",
+          "anyOf": [
+            {
+              "description": "All possible notifications that a client can send to an agent.\n\nThis enum is used internally for routing RPC notifications. You typically won't need\nto use this directly.\n\nNotifications do not expect a response.",
+              "anyOf": [
+                {
+                  "title": "CancelSessionNotification",
+                  "description": "Cancels ongoing operations for a session.\n\nThis is a notification sent by the client to cancel active work in a\nsession.\n\nUpon receiving this notification, the Agent SHOULD:\n- Stop all language model requests as soon as possible\n- Abort all tool call invocations in progress\n- Send any pending `session/update` notifications\n- Report an idle `state_update` with `StopReason::Cancelled` after\n  cancellation succeeds\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle#cancellation)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/CancelSessionNotification"
+                    }
+                  ]
+                },
+                {
+                  "title": "ExtNotification",
+                  "description": "Handles extension notifications from the client.\n\nExtension notifications provide a way to send one-way messages for custom functionality\nwhile maintaining protocol compatibility.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/ExtNotification"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": ["method"],
+      "x-docs-ignore": true
+    },
+    "CancelSessionNotification": {
+      "description": "Notification to cancel ongoing operations for a session.\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/v2/prompt-lifecycle#cancellation)",
+      "type": "object",
+      "properties": {
+        "sessionId": {
+          "description": "The ID of the session to cancel operations for.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/SessionId"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["sessionId"],
+      "x-side": "agent",
+      "x-method": "session/cancel"
+    },
+    "ProtocolLevelNotification": {
+      "description": "A JSON-RPC notification object.",
+      "type": "object",
+      "properties": {
+        "method": {
+          "description": "The notification method name.",
+          "type": "string"
+        },
+        "params": {
+          "description": "Method-specific notification parameters.",
+          "anyOf": [
+            {
+              "description": "General protocol-level notifications that all sides are expected to\nimplement.\n\nNotifications whose methods start with '$/' are messages which\nare protocol implementation dependent and might not be implementable in all\nclients or agents. For example if the implementation uses a single threaded\nsynchronous programming language then there is little it can do to react to\na `$/cancel_request` notification. If an agent or client receives\nnotifications starting with '$/' it is free to ignore the notification.\n\nNotifications do not expect a response.",
+              "anyOf": [
+                {
+                  "title": "CancelRequestNotification",
+                  "description": "Cancels an ongoing request.\n\nThis is a notification sent by the side that sent a request to cancel that request.\n\nUpon receiving this notification, the receiver:\n\n1. MAY cancel the corresponding request activity and all nested activities\n2. MAY send any pending notifications.\n3. MUST send one of these responses for the original request:\n  - Valid response with appropriate data (partial results or cancellation marker)\n  - Error response with code `-32800` (Cancelled)\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/v2/cancellation)",
+                  "allOf": [
+                    {
+                      "$ref": "#/$defs/CancelRequestNotification"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": ["method"],
+      "x-docs-ignore": true
+    },
+    "CancelRequestNotification": {
+      "description": "Notification to cancel an ongoing request.\n\nSee protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/v2/cancellation)",
+      "type": "object",
+      "properties": {
+        "requestId": {
+          "description": "The ID of the request to cancel.",
+          "allOf": [
+            {
+              "$ref": "#/$defs/RequestId"
+            }
+          ]
+        },
+        "_meta": {
+          "description": "The _meta property is reserved by ACP to allow clients and agents to attach additional\nmetadata to their interactions. Implementations MUST NOT make assumptions about values at\nthese keys.\n\nSee protocol docs: [Extensibility](https://agentclientprotocol.com/protocol/v2/extensibility)",
+          "type": ["object", "null"],
+          "x-deserialize-default-on-error": true,
+          "additionalProperties": true
+        }
+      },
+      "required": ["requestId"],
+      "x-side": "protocol",
+      "x-method": "$/cancel_request"
+    }
+  }
+}


### PR DESCRIPTION
Closes #30 (epic) and its children #27, #28, #29. Stacked on PR #31 (base = `feat/acp-v1-gap-closure`).

## Version selection — no ambiguity by construction (#27)
- **v1 stays the default.** `AcpServerOptions.EnableV2Alpha` is the explicit opt-in; without it, a client requesting v2 is negotiated down to v1.
- One source of truth per concern: `AcpVersions` (constants), `AcpServerOptions.SupportedVersions` (what this server serves), `AcpConnectionState.ProtocolVersion` (what this connection speaks), `AcpMethodRegistry` (which methods exist in which version, derived from the vendored `meta.json` files).
- **Central dispatch gate:** `session/load` on a v2 connection or `auth/login` on a v1 connection → method-not-found, regardless of registration.

## v2 wire layer (#28) — separate `Protocol.V2` namespace
- v2 initialize (required `info`, `{}`-marker capabilities, `methodId` auth methods); `auth/login`/`auth/logout`.
- `AcpSessionHandlerV2`: v2 `session/new` (optional `mcpServers`, no `modes`), `session/resume` + `replayFrom:{"type":"start"}` replacing `session/load`, baseline `list`/`close`, gated `delete`, v2 `set_config_option` (`type` required, `id`/`boolean` variants), and the **inverted prompt lifecycle**: `state_update running` → updates → `state_update idle {stopReason}` → empty `{}` ACK.
- `SessionUpdateStreamerV2`: required `messageId` chunks, `tool_call_update` upserts, `plan_update` with `planId`, reworked v2 diff mapping, `configId`/`groupId` names, `SendCurrentModeAsync` correctly unsupported on v2.
- `AcpClient` emits the v2 permission shape (required `title`, `subject` union) on v2 connections. The provider API (`IAgentProvider` + optional interfaces) stays version-neutral — existing agents serve both versions unchanged.

## Tests + docs (#29)
- v2 alpha schema (`schema-v2.0.0-alpha.x`) vendored alongside v1; `AcpSchema` validates against either.
- 15 new tests: negotiation matrix, v2 initialize shape, full v2 e2e prompt flow with **every notification schema-validated**, version gating both directions, cross-version (v1 client on v2-enabled server), v2 streamer shapes.
- README documents version choice, the sources of truth table, and the v1→v2 differences handled automatically.

## Verification
**325 tests pass** (15 new); all pre-existing v1 tests pass untouched — v1 behavior is unchanged when v2 is not negotiated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)