### PR TITLE
fix: post-review hardening — robustness + docs (#33)

### DIFF
--- a/ACP_IMPLEMENTATION_PLAN.md
+++ b/ACP_IMPLEMENTATION_PLAN.md
@@ -1,5 +1,14 @@
 # ACP Protocol Implementation Plan for Andy.Acp.Core
 
+> **⚠️ SUPERSEDED — historical document.** This plan describes the original
+> pre-v1 architecture and is kept for history only. The implementation has
+> since been reworked for stable ACP v1 (plus opt-in v2 alpha): `initialized`
+> and `shutdown` were never part of ACP and were removed, and filesystem /
+> terminal are agent → client requests (`AcpClient` in `src/Andy.Acp.Core/Client/`)
+> rather than the inbound `IFileSystemProvider` / `ITerminalProvider` /
+> `AcpFileSystemHandler` / `AcpTerminalHandler` design planned below.
+> See `README.md` for the current architecture.
+
 ## Goal
 Implement the complete Agent Client Protocol (ACP) in Andy.Acp.Core as a general-purpose library that any agent can use to integrate with ACP-compatible editors like Zed.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ andy-acp/
 │       ├── Server/                 # Unified ACP server
 │       └── Tools/                  # Tool framework (MCP compatibility)
 ├── tests/
-│   └── Andy.Acp.Tests/             # Comprehensive unit tests (303 tests)
+│   └── Andy.Acp.Tests/             # Comprehensive unit tests (334 tests)
 │       ├── Transport/
 │       ├── JsonRpc/
 │       ├── Session/
@@ -155,7 +155,7 @@ andy-acp/
 - **Response streaming** working (word-by-word display in Zed)
 - **Session management** properly tracking conversation state
 
-**Total: 303 tests passing** (including schema-backed ACP v1 validation and end-to-end stdio flows)
+**Total: 334 tests passing** (including schema-backed ACP v1 validation and end-to-end stdio flows)
 
 ## Supported ACP version and capabilities
 

--- a/docs/ZED_INTEGRATION_TESTING.md
+++ b/docs/ZED_INTEGRATION_TESTING.md
@@ -89,17 +89,19 @@ echo '{"jsonrpc":"2.0","method":"tools/list","id":1,"params":{}}' | dotnet run -
 The following should happen automatically (check server stderr logs):
 
 - [ ] Zed sends `initialize` request
-- [ ] Server responds with capabilities (tools, resources, logging)
-- [ ] Zed sends `initialized` notification
+- [ ] Server responds with ACP agent capabilities
+- [ ] Zed sends `session/new` request and the server creates a session
 - [ ] Session becomes active
 - [ ] No JSON-RPC errors reported
+
+> **Note:** ACP has no `initialized` notification or `shutdown` method (they were
+> never part of the ACP spec and are not implemented).
 
 **Expected stderr logs:**
 ```
 [SERVER] Processing JSON-RPC request: initialize (ID: 1)
+[SERVER] Processing JSON-RPC request: session/new (ID: 2)
 [SERVER] Created new session: {session-id}
-[SERVER] Processing JSON-RPC request: initialized
-[SERVER] Session {session-id} is now active
 ```
 
 ### 3. Tool Discovery
@@ -328,26 +330,18 @@ echo 'invalid json' | dotnet run -- --server
 - [ ] Session timeout is set (default: 30 minutes)
 - [ ] Pending requests are tracked
 
-#### Graceful Shutdown
+#### Connection Close
 
-**Request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "shutdown",
-  "id": 9,
-  "params": {
-    "reason": "Testing complete"
-  }
-}
-```
+ACP has no `shutdown` method. The server exits when the client closes the
+connection (stdin reaches end-of-stream).
 
 **Expected behavior:**
-- [ ] Server waits up to 5 seconds for pending requests
-- [ ] All pending requests complete or timeout
-- [ ] Session transitions to terminated state
-- [ ] Success response returned
-- [ ] Connection closes cleanly
+- [ ] In-flight handlers get up to 5 seconds to flush final updates/responses
+- [ ] Pending agent-to-client requests are failed with a disconnect error
+- [ ] The transport is closed and the process exits cleanly
+
+Test manually by closing Zed (or sending EOF to the server's stdin) and
+checking the stderr logs for a clean stop.
 
 ### 7. Performance Metrics
 
@@ -396,7 +390,8 @@ done
 
 ### Issue: "Session timeout"
 **Solution:**
-- Ensure `initialized` notification is sent after `initialize`
+- Ensure `initialize` completed successfully before any `session/*` method
+  (session methods fail with a not-initialized error otherwise)
 - Check session state in server logs
 - Verify session timeout setting (default: 30 minutes)
 
@@ -419,7 +414,7 @@ done
 3. **Discovery**: Check Zed can see all 4 tools
 4. **Execution**: Test each tool at least once
 5. **Errors**: Test at least one error condition
-6. **Shutdown**: Close Zed and verify graceful shutdown
+6. **Disconnect**: Close Zed and verify the server exits cleanly on connection close
 
 ## Automated Testing
 

--- a/src/Andy.Acp.Core/Protocol/AcpProtocolHandler.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpProtocolHandler.cs
@@ -11,9 +11,9 @@ using Andy.Acp.Core.JsonRpc;
 namespace Andy.Acp.Core.Protocol
 {
     /// <summary>
-    /// Handles the ACP v1 <c>initialize</c> handshake and protocol-version negotiation.
-    /// Unlike earlier revisions, this does not register <c>initialized</c> or
-    /// <c>shutdown</c> (neither is part of ACP v1), and it does not create a conversation
+    /// Handles the ACP <c>initialize</c> handshake and protocol-version negotiation for
+    /// both stable v1 and (when enabled) v2 alpha. It does not register <c>initialized</c>
+    /// or <c>shutdown</c> (neither is part of ACP), and it does not create a conversation
     /// session — that is the job of <c>session/new</c>. It records the outcome in the shared
     /// <see cref="AcpConnectionState"/> so session methods can enforce initialize-first ordering.
     /// </summary>
@@ -132,13 +132,17 @@ namespace Andy.Acp.Core.Protocol
 
         /// <summary>
         /// Applies the ACP version-negotiation rule against the configured supported set:
-        /// a supported requested version is used as-is; anything else falls back to the
-        /// highest supported version so the client can decide whether to proceed.
+        /// a supported requested version is used as-is; anything else falls back to stable
+        /// v1 when served, so alpha versions are only negotiated on an explicit client
+        /// request. (Without v1 in the set, the highest supported version is used.)
         /// </summary>
         private int NegotiateVersion(int? requested)
         {
             if (requested.HasValue && _supportedVersions.Contains(requested.Value))
                 return requested.Value;
+
+            if (_supportedVersions.Contains(AcpVersions.V1))
+                return AcpVersions.V1;
 
             return _supportedVersions.Max();
         }

--- a/src/Andy.Acp.Core/Protocol/AcpSessionHandler.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpSessionHandler.cs
@@ -369,7 +369,7 @@ namespace Andy.Acp.Core.Protocol
                     _logger?.LogInformation("Prompt completed for session {SessionId}, stopReason {StopReason}",
                         promptParams.SessionId, response.StopReason);
 
-                    return new { stopReason = MapStopReason(response.StopReason) };
+                    return new { stopReason = AcpStopReason.ToWire(response.StopReason) };
                 }
                 catch (OperationCanceledException)
                 {
@@ -523,16 +523,6 @@ namespace Andy.Acp.Core.Protocol
             var json = JsonSerializer.Serialize(parameters, JsonRpcSerializer.Options);
             return JsonSerializer.Deserialize<T>(json, JsonRpcSerializer.Options);
         }
-
-        private static string MapStopReason(StopReason stopReason) => stopReason switch
-        {
-            StopReason.Completed => "end_turn",
-            StopReason.Cancelled => "cancelled",
-            StopReason.TokenLimit => "max_tokens",
-            StopReason.Error => "refusal",
-            StopReason.TimeLimit => "max_tokens",
-            _ => "end_turn"
-        };
 
         private class NewSessionRequest
         {

--- a/src/Andy.Acp.Core/Protocol/AcpStopReason.cs
+++ b/src/Andy.Acp.Core/Protocol/AcpStopReason.cs
@@ -1,0 +1,31 @@
+using Andy.Acp.Core.Agent;
+
+namespace Andy.Acp.Core.Protocol
+{
+    /// <summary>
+    /// The single mapping from the provider-level <see cref="StopReason"/> to the ACP
+    /// wire value, shared by the v1 prompt response and the v2 <c>state_update</c>.
+    /// ACP defines only <c>end_turn</c>, <c>max_tokens</c>, <c>max_turn_requests</c>,
+    /// <c>refusal</c>, and <c>cancelled</c>, so two provider reasons have no exact match:
+    /// <list type="bullet">
+    /// <item><see cref="StopReason.TimeLimit"/> maps to <c>max_turn_requests</c>
+    /// (budget/limit exhaustion, not token-specific).</item>
+    /// <item><see cref="StopReason.Error"/> maps to <c>refusal</c> — the closest
+    /// "turn did not complete normally" value; <c>end_turn</c> would falsely claim
+    /// success. Agents should report the actual error via message content.</item>
+    /// </list>
+    /// </summary>
+    public static class AcpStopReason
+    {
+        /// <summary>Maps a provider stop reason to its ACP wire string.</summary>
+        public static string ToWire(StopReason stopReason) => stopReason switch
+        {
+            StopReason.Completed => "end_turn",
+            StopReason.Cancelled => "cancelled",
+            StopReason.TokenLimit => "max_tokens",
+            StopReason.TimeLimit => "max_turn_requests",
+            StopReason.Error => "refusal",
+            _ => "end_turn"
+        };
+    }
+}

--- a/src/Andy.Acp.Core/Protocol/V2/AcpSessionHandlerV2.cs
+++ b/src/Andy.Acp.Core/Protocol/V2/AcpSessionHandlerV2.cs
@@ -295,7 +295,7 @@ namespace Andy.Acp.Core.Protocol.V2
                 {
                     var response = await _agentProvider.ProcessPromptAsync(
                         req.SessionId, message, streamer, promptCts.Token);
-                    stopReason = MapStopReason(response.StopReason);
+                    stopReason = AcpStopReason.ToWire(response.StopReason);
                 }
                 catch (OperationCanceledException)
                 {
@@ -401,16 +401,6 @@ namespace Andy.Acp.Core.Protocol.V2
             var json = JsonSerializer.Serialize(parameters, JsonRpcSerializer.Options);
             return JsonSerializer.Deserialize<T>(json, JsonRpcSerializer.Options);
         }
-
-        private static string MapStopReason(StopReason stopReason) => stopReason switch
-        {
-            StopReason.Completed => "end_turn",
-            StopReason.Cancelled => "cancelled",
-            StopReason.TokenLimit => "max_tokens",
-            StopReason.Error => "refusal",
-            StopReason.TimeLimit => "max_tokens",
-            _ => "end_turn"
-        };
 
         private class NewSessionRequestV2
         {

--- a/src/Andy.Acp.Core/Protocol/V2/SessionUpdateStreamerV2.cs
+++ b/src/Andy.Acp.Core/Protocol/V2/SessionUpdateStreamerV2.cs
@@ -131,10 +131,16 @@ namespace Andy.Acp.Core.Protocol.V2
             }, cancellationToken);
 
         public Task SendCurrentModeAsync(string modeId, CancellationToken cancellationToken)
+        {
             // v2 removed current_mode_update: modes are config options (category "mode").
-            => throw new NotSupportedException(
-                "ACP v2 has no current_mode_update; report mode changes via SendConfigOptionsAsync " +
-                "with a config option of category \"mode\".");
+            // IResponseStreamer is version-neutral, so dropping with a warning beats
+            // crashing an in-flight prompt whose agent doesn't know the wire version.
+            _logger?.LogWarning(
+                "ACP v2 has no current_mode_update; dropping mode change {ModeId}. " +
+                "Report mode changes via SendConfigOptionsAsync with a config option of category \"mode\".",
+                modeId);
+            return Task.CompletedTask;
+        }
 
         public Task SendConfigOptionsAsync(IReadOnlyList<SessionConfigOption> configOptions, CancellationToken cancellationToken)
             => SendUpdateAsync(new

--- a/src/Andy.Acp.Core/Server/AcpServer.cs
+++ b/src/Andy.Acp.Core/Server/AcpServer.cs
@@ -262,6 +262,29 @@ namespace Andy.Acp.Core.Server
                             _logger?.LogInformation("Input stream closed");
                             break;
                         }
+                        catch (InvalidOperationException ex)
+                        {
+                            // Recoverable framing error (e.g. a garbage line): the bad
+                            // frame was consumed, so report it as a JSON-RPC parse error
+                            // and keep serving subsequent messages instead of killing
+                            // the whole connection.
+                            _logger?.LogWarning(ex, "Skipping malformed message frame");
+                            try
+                            {
+                                var errorJson = JsonRpcSerializer.Serialize(
+                                    JsonRpcSerializer.CreateErrorResponse(
+                                        requestId: null,
+                                        JsonRpcErrorCodes.CreateError(
+                                            JsonRpcErrorCodes.ParseError,
+                                            "Malformed message frame")));
+                                await transport.WriteMessageAsync(errorJson, cancellationToken).ConfigureAwait(false);
+                            }
+                            catch (Exception writeEx)
+                            {
+                                _logger?.LogWarning(writeEx, "Failed to report framing error; continuing");
+                            }
+                            continue;
+                        }
                         catch (Exception ex)
                         {
                             _logger?.LogError(ex, "Error reading message; stopping read loop");
@@ -368,12 +391,13 @@ namespace Andy.Acp.Core.Server
                     if (request.Method == "$/cancel_request")
                     {
                         // ACP protocol-level cancellation: cancel the in-flight request with
-                        // the given id. This is a notification; no response is sent.
+                        // the given id. Defined as a notification; when a client still sends
+                        // it with an id, answer with an empty success so it is not left hanging.
                         HandleCancelRequest(request);
-                        return;
+                        if (!request.IsNotification)
+                            response = JsonRpcSerializer.CreateSuccessResponse(request);
                     }
-
-                    if (!request.IsNotification)
+                    else if (!request.IsNotification)
                     {
                         // Track cancellable in-flight requests by canonical id.
                         var key = CanonicalId(request.Id);

--- a/src/Andy.Acp.Core/Session/AcpSession.cs
+++ b/src/Andy.Acp.Core/Session/AcpSession.cs
@@ -156,8 +156,8 @@ namespace Andy.Acp.Core.Session
                 // Set initial context
                 if (capabilities.ClientInfo != null)
                 {
-                    SetContextValue("client.name", capabilities.ClientInfo.Name);
-                    SetContextValue("client.version", capabilities.ClientInfo.Version);
+                    SetContextValue("client.name", capabilities.ClientInfo.Name ?? string.Empty);
+                    SetContextValue("client.version", capabilities.ClientInfo.Version ?? string.Empty);
                 }
 
                 State = SessionState.Initialized;

--- a/src/Andy.Acp.Core/Transport/StdioTransport.cs
+++ b/src/Andy.Acp.Core/Transport/StdioTransport.cs
@@ -75,7 +75,7 @@ namespace Andy.Acp.Core.Transport
             _inputStream = inputStream ?? throw new ArgumentNullException(nameof(inputStream));
             _outputStream = outputStream ?? throw new ArgumentNullException(nameof(outputStream));
             _ownsStreams = false;
-            _lineTerminator = "\r\n";
+            _lineTerminator = "\n";
             _maxMessageSize = maxMessageSize;
 
             _logger?.LogDebug("StdioTransport initialized (byte framing)");

--- a/tests/Andy.Acp.Tests/Protocol/AcpStopReasonTests.cs
+++ b/tests/Andy.Acp.Tests/Protocol/AcpStopReasonTests.cs
@@ -1,0 +1,29 @@
+using Andy.Acp.Core.Agent;
+using Andy.Acp.Core.Protocol;
+using Xunit;
+
+namespace Andy.Acp.Tests.Protocol
+{
+    /// <summary>
+    /// Pins the shared provider-to-wire stop-reason mapping (epic #33).
+    /// </summary>
+    public class AcpStopReasonTests
+    {
+        [Theory]
+        [InlineData(StopReason.Completed, "end_turn")]
+        [InlineData(StopReason.Cancelled, "cancelled")]
+        [InlineData(StopReason.TokenLimit, "max_tokens")]
+        [InlineData(StopReason.TimeLimit, "max_turn_requests")]
+        [InlineData(StopReason.Error, "refusal")]
+        public void ToWire_MapsAllProviderReasons(StopReason reason, string expected)
+        {
+            Assert.Equal(expected, AcpStopReason.ToWire(reason));
+        }
+
+        [Fact]
+        public void ToWire_UnknownReason_FallsBackToEndTurn()
+        {
+            Assert.Equal("end_turn", AcpStopReason.ToWire((StopReason)999));
+        }
+    }
+}

--- a/tests/Andy.Acp.Tests/Protocol/V2/V2ProtocolTests.cs
+++ b/tests/Andy.Acp.Tests/Protocol/V2/V2ProtocolTests.cs
@@ -41,8 +41,9 @@ namespace Andy.Acp.Tests.Protocol.V2
         [InlineData(false, 1, 1)] // v1-only server, v1 request -> v1
         [InlineData(false, 2, 1)] // v1-only server, v2 request -> negotiated down to v1
         [InlineData(true, 1, 1)]  // v1+v2 server, v1 request -> v1
-        [InlineData(true, 2, 2)]  // v1+v2 server, v2 request -> v2
-        [InlineData(true, 99, 2)] // unsupported request -> highest supported
+        [InlineData(true, 2, 2)]  // v1+v2 server, explicit v2 request -> v2
+        [InlineData(true, 99, 1)] // unsupported request -> stable fallback, not alpha
+        [InlineData(true, 0, 1)]  // unsupported low request -> stable fallback, not alpha
         public async Task Negotiation_Matrix(bool v2Enabled, int requested, int expected)
         {
             var (handler, state) = Handler(v2Enabled);
@@ -312,11 +313,13 @@ namespace Andy.Acp.Tests.Protocol.V2
         }
 
         [Fact]
-        public async Task V2Streamer_CurrentMode_IsNotSupported()
+        public async Task V2Streamer_CurrentMode_IsDroppedWithoutThrowing()
         {
-            var (streamer, _) = V2Streamer();
-            await Assert.ThrowsAsync<NotSupportedException>(
-                () => streamer.SendCurrentModeAsync("chat", CancellationToken.None));
+            // v2 has no current_mode_update; the version-neutral streamer API must not
+            // crash an in-flight prompt — the update is dropped (with a log warning).
+            var (streamer, transport) = V2Streamer();
+            await streamer.SendCurrentModeAsync("chat", CancellationToken.None);
+            Assert.Empty(transport.Messages);
         }
 
         private static (SessionUpdateStreamerV2 streamer, CapturingTransport transport) V2Streamer()

--- a/tests/Andy.Acp.Tests/Server/ReadLoopRobustnessTests.cs
+++ b/tests/Andy.Acp.Tests/Server/ReadLoopRobustnessTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Acp.Core.Agent;
+using Andy.Acp.Core.JsonRpc;
+using Andy.Acp.Core.Server;
+using Xunit;
+
+namespace Andy.Acp.Tests.Server
+{
+    /// <summary>
+    /// Read-loop robustness (epic #33): a malformed frame must not kill the server,
+    /// and $/cancel_request sent with an id must still get a response.
+    /// </summary>
+    public class ReadLoopRobustnessTests
+    {
+        [Fact]
+        public async Task MalformedFrame_IsAnsweredWithParseError_AndServerKeepsServing()
+        {
+            var harness = new InMemoryDuplex();
+            var server = new AcpServer(new StubAgent());
+
+            using var serverCts = new CancellationTokenSource();
+            var serverTask = server.RunAsync(harness.ServerTransport, serverCts.Token);
+
+            // A garbage line: not JSON, not Content-Length framing.
+            await harness.SendAsync("this is not a json-rpc message");
+
+            var errorJson = await harness.ReadMessageAsync();
+            var errorRoot = JsonDocument.Parse(errorJson).RootElement;
+            Assert.Equal(JsonRpcErrorCodes.ParseError, errorRoot.GetProperty("error").GetProperty("code").GetInt32());
+
+            // The connection survived: a well-formed request right after is handled.
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{}}}""");
+            var initJson = await harness.ReadMessageAsync();
+            var initRoot = JsonDocument.Parse(initJson).RootElement;
+            Assert.Equal(1, initRoot.GetProperty("id").GetInt32());
+            Assert.Equal(1, initRoot.GetProperty("result").GetProperty("protocolVersion").GetInt32());
+
+            serverCts.Cancel();
+            harness.Complete();
+            try { await serverTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
+        }
+
+        [Fact]
+        public async Task CancelRequest_SentWithId_StillGetsAResponse()
+        {
+            var harness = new InMemoryDuplex();
+            var server = new AcpServer(new StubAgent());
+
+            using var serverCts = new CancellationTokenSource();
+            var serverTask = server.RunAsync(harness.ServerTransport, serverCts.Token);
+
+            // $/cancel_request is defined as a notification, but a client sending it
+            // with an id must not be left hanging.
+            await harness.SendAsync("""{"jsonrpc":"2.0","id":5,"method":"$/cancel_request","params":{"requestId":999}}""");
+
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var responseJson = await harness.ReadMessageAsync(timeout.Token);
+            var root = JsonDocument.Parse(responseJson).RootElement;
+            Assert.Equal(5, root.GetProperty("id").GetInt32());
+            Assert.True(root.TryGetProperty("result", out _));
+            Assert.False(root.TryGetProperty("error", out _));
+
+            serverCts.Cancel();
+            harness.Complete();
+            try { await serverTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
+        }
+
+        private sealed class StubAgent : IAgentProvider
+        {
+            public Task<AgentResponse> ProcessPromptAsync(string sessionId, PromptMessage prompt, IResponseStreamer streamer, CancellationToken cancellationToken)
+                => Task.FromResult(new AgentResponse { StopReason = StopReason.Completed });
+            public Task<SessionMetadata> CreateSessionAsync(NewSessionParams? parameters, CancellationToken cancellationToken)
+                => Task.FromResult(new SessionMetadata { SessionId = "s1" });
+            public Task<SessionMetadata?> LoadSessionAsync(LoadSessionParams parameters, IResponseStreamer streamer, CancellationToken cancellationToken)
+                => Task.FromResult<SessionMetadata?>(null);
+            public Task CancelSessionAsync(string sessionId, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task<bool> SetSessionModeAsync(string sessionId, string modeId, CancellationToken cancellationToken) => Task.FromResult(true);
+            public AgentCapabilities GetCapabilities() => new();
+        }
+    }
+}

--- a/tests/Andy.Acp.Tests/Tools/AcpToolsTests.cs
+++ b/tests/Andy.Acp.Tests/Tools/AcpToolsTests.cs
@@ -125,7 +125,7 @@ namespace Andy.Acp.Tests.Tools
             Assert.NotNull(echoTool.InputSchema);
             Assert.Equal("object", echoTool.InputSchema.Type);
             Assert.Contains("text", echoTool.InputSchema.Properties.Keys);
-            Assert.Contains("text", echoTool.InputSchema.Required);
+            Assert.Contains("text", echoTool.InputSchema.Required!);
         }
 
         [Fact]

--- a/tests/Andy.Acp.Tests/Transport/StdioTransportTests.cs
+++ b/tests/Andy.Acp.Tests/Transport/StdioTransportTests.cs
@@ -113,8 +113,9 @@ namespace Andy.Acp.Tests.Transport
             // Assert
             var output = _streamProvider.GetOutputData();
             var json = JsonSerializer.Serialize(testMessage);
-            // StdioTransport now uses line-delimited JSON format (not Content-Length headers)
-            var expectedOutput = $"{json}\r\n";
+            // StdioTransport uses line-delimited JSON with a \n terminator (not
+            // Content-Length headers), identical across both constructors.
+            var expectedOutput = $"{json}\n";
             Assert.Equal(expectedOutput, output);
         }
 


### PR DESCRIPTION
Implements everything in epic #33 (findings from the post-merge review of the ACP v1 conformance + v2 alpha work).

## Bugs / robustness
- **Malformed frame no longer kills the server** — the read loop answers with a JSON-RPC `-32700` parse error and continues, instead of terminating the connection (`AcpServer`)
- **`$/cancel_request` sent with an id gets an empty success response** — clients that send it as a request are no longer left hanging
- **Version negotiation falls back to stable v1** for unsupported/absent requested versions; v2 alpha is only negotiated on an explicit request
- **V2 `SendCurrentModeAsync` drops with a log warning** instead of throwing `NotSupportedException` mid-prompt (the `IResponseStreamer` API is version-neutral)
- **Stop-reason mapping centralized** in `AcpStopReason.ToWire` (shared by v1 + v2 handlers); `TimeLimit → max_turn_requests`, `Error → refusal` (trade-off documented)

## Docs / staleness
- README test count corrected (303 → 334)
- `ZED_INTEGRATION_TESTING.md`: removed expectations for the non-ACP `initialized` notification and `shutdown` method; documents EOF-based connection close
- `ACP_IMPLEMENTATION_PLAN.md` marked superseded
- `StdioTransport` line terminator unified (`\n`) across constructors
- Nullable warnings fixed; `AcpProtocolHandler` docstring updated for v1+v2

## Verification
- Build: 0 errors, 0 warnings (was 3 warnings)
- Tests: **334/334 passing** (325 existing + 9 new/updated, incl. e2e read-loop recovery and cancel-with-id tests)

Closes #33